### PR TITLE
minor bug-fix for LOS/AOS behavoir of LEM RR by CSM RRT

### DIFF
--- a/Orbitersdk/samples/ProjectApollo/src_csm/csm_telecom.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_csm/csm_telecom.cpp
@@ -5238,8 +5238,7 @@ void RNDZXPDRSystem::SendRF()
 	}
 	else //act like a radar reflector, this is also a function of orientation and skin temperature of the CSM, but this should work.
 	{
-		//deleted. unless someone can find positive confirmation that the LM RR had the ability to skin-track the CSM
-		//sat->CSM_RRTto_LM_RRConnector.SendRF(RCVDfreq, (pow(10.0, RCVDPowerdB / 10.0) / 1000)*0.85*((sin(theta*RAD) + 1) / 2), 45.4, 0.0); //should give a radar cross section of ~5m^2 side on, ~=5kM range
+		sat->CSM_RRTto_LM_RRConnector.SendRF(RCVDfreq, (pow(10.0, RCVDPowerdB / 10.0) / 1000)*0.85*((sin(theta*RAD) + 1) / 2), 12.0, 0.0); //should give a radar cross section of ~5m^2 side on, ~=5kM range
 	}
 }
 

--- a/Orbitersdk/samples/ProjectApollo/src_lm/lm_rr.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_lm/lm_rr.cpp
@@ -121,6 +121,7 @@ void LEM_RR::Init(LEM *s, e_object *dc_src, e_object *ac_src, h_Radiator *ant, B
 	AntennaPower = 0.240; //W
 	AntennaFrequency = 9832.8; //MHz
 	AntennaPhase = 0.0;
+	AntennaPolarValue = 1.0;
 
 	RCVDfreq = 0.0;
 	RCVDpow = 0.0;
@@ -294,6 +295,7 @@ void LEM_RR::Timestep(double simdt) {
 				break;
 			}
 		}
+		lem->lm_rr_to_csm_connector.SendRF(AntennaFrequency, 0.0, AntennaGain*AntennaPolarValue, AntennaPhase);
 		return;
 	}
 
@@ -753,7 +755,10 @@ void LEM_RR::Timestep(double simdt) {
 	//sprintf(oapiDebugString(), "RRDataGood: %d ruptSent: %d  RadarActivity: %d Range: %f", val33[RRDataGood] == 0, ruptSent, val13[RadarActivity] == 1, range);
 
 	//send data out to the CSM RRT
-	lem->lm_rr_to_csm_connector.SendRF(AntennaFrequency, AntennaPower, AntennaGain*AntennaPolarValue, AntennaPhase);
+	if (IsPowered())
+	{
+		lem->lm_rr_to_csm_connector.SendRF(AntennaFrequency, AntennaPower, AntennaGain*AntennaPolarValue, AntennaPhase);
+	}
 }
 
 void LEM_RR::SystemTimestep(double simdt) {


### PR DESCRIPTION
fix bug where transponder would not recognize when LM RR was switched off. also re-added skin-tracking with a much lower gain, because its probable that this would work to some degree, and also catches some loss-of-signal conditions where the XPNDR is off.