### PR TITLE
Remove VoltageAlarm, Correct PGNS light

### DIFF
--- a/Orbitersdk/samples/ProjectApollo/src_csm/CSMcomputer.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_csm/CSMcomputer.cpp
@@ -183,7 +183,6 @@ void CSMcomputer::Timestep(double simt, double simdt)
 			// Also, simulate the operation of the VOLTAGE ALARM, turn off STBY and RESTART light while power is off.
 			// The RESTART light will come on as soon as the AGC receives power again.
 			// This happens externally to the AGC program. See CSM 104 SYS HBK pg 399
-			vagc.VoltageAlarm = 1;
 			vagc.RestartLight = 1;
 			dsky.ClearRestart();
 			dsky2.ClearRestart();

--- a/Orbitersdk/samples/ProjectApollo/src_csm/CSMcomputer.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_csm/CSMcomputer.cpp
@@ -345,6 +345,8 @@ void CSMcomputer::ProcessChannel10(ChannelValue val){
 	if (val10.Bits.a == 12) {
 		// Gimbal Lock
 		GimbalLockAlarm = ((val10.Value & (1 << 5)) != 0);
+		// Tracker alarm
+		TrackerAlarm = ((val10.Value & (1 << 7)) != 0);
 		// Prog alarm
 		ProgAlarm = ((val10.Value & (1 << 8)) != 0);
 	}

--- a/Orbitersdk/samples/ProjectApollo/src_csm/satsystems.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_csm/satsystems.cpp
@@ -3595,6 +3595,9 @@ void Saturn::GetAGCWarningStatus(AGCWarningStatus &aws)
 	// Restart alarm
 	if (agc.vagc.RestartLight)
 		aws.PGNSWarning = true;
+	// Tracker alarm
+	if (agc.GetTrackerAlarm())
+		aws.PGNSWarning = true;
 	// Gimbal Lock 
 	if (agc.GetGimbalLockAlarm()) 
 		aws.PGNSWarning = true;

--- a/Orbitersdk/samples/ProjectApollo/src_csm/satsystems.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_csm/satsystems.cpp
@@ -3593,7 +3593,7 @@ void Saturn::GetAGCWarningStatus(AGCWarningStatus &aws)
 		
 	aws.PGNSWarning = false;
 	// Restart alarm
-	if (agc.vagc.VoltageAlarm != 0) 
+	if (agc.vagc.RestartLight)
 		aws.PGNSWarning = true;
 	// Gimbal Lock 
 	if (agc.GetGimbalLockAlarm()) 

--- a/Orbitersdk/samples/ProjectApollo/src_lm/LEMcomputer.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_lm/LEMcomputer.cpp
@@ -164,7 +164,6 @@ void LEMcomputer::Timestep(double simt, double simdt)
 		// Also, simulate the operation of the VOLTAGE ALARM, turn off STBY and RESTART light while power is off.
 		// The RESTART light will come on as soon as the AGC receives power again.
 		// This happens externally to the AGC program. See CSM 104 SYS HBK pg 399
-		vagc.VoltageAlarm = 1;
 		vagc.RestartLight = 1;
 		dsky.ClearRestart();
 		dsky.ClearStby();

--- a/Orbitersdk/samples/ProjectApollo/src_sys/apolloguidance.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_sys/apolloguidance.cpp
@@ -74,6 +74,7 @@ ApolloGuidance::ApolloGuidance(SoundLib &s, DSKY &display, IMU &im, CDU &sc, CDU
 	PadLoaded = false;
 
 	ProgAlarm = false;
+	TrackerAlarm = false;
 	GimbalLockAlarm = false;
 
 	//
@@ -449,6 +450,7 @@ void ApolloGuidance::SaveState(FILEHANDLE scn)
 	}
 
 	papiWriteScenario_bool(scn, "PROGALARM", ProgAlarm);
+	papiWriteScenario_bool(scn, "TRACKERALARM", TrackerAlarm);
 	papiWriteScenario_bool(scn, "GIMBALLOCKALARM", GimbalLockAlarm);
 
 	oapiWriteLine(scn, AGC_END_STRING);
@@ -565,6 +567,7 @@ void ApolloGuidance::LoadState(FILEHANDLE scn)
 		}
 
 		papiReadScenario_bool(line, "PROGALARM", ProgAlarm);
+		papiReadScenario_bool(line, "TRACKERALARM", TrackerAlarm);
 		papiReadScenario_bool(line, "GIMBALLOCKALARM", GimbalLockAlarm);
 	}
 }

--- a/Orbitersdk/samples/ProjectApollo/src_sys/apolloguidance.h
+++ b/Orbitersdk/samples/ProjectApollo/src_sys/apolloguidance.h
@@ -297,7 +297,7 @@ public:
 	/// \param a Power bus 1.
 	/// \param b Power bus 2.
 	///
-	void WirePower(e_object *a, e_object *b) { DCPower.WireToBuses(a, b); };
+	void WirePower(e_object *a, e_object *b) { DCPower.WireToBuses(a, b); }
 
 	///
 	/// \brief Is the AGC supplied with power.
@@ -305,13 +305,14 @@ public:
 	///
 	bool IsPowered();
 
-	void SetDSKY2(DSKY *d2) { dsky2 = d2; };
+	void SetDSKY2(DSKY *d2) { dsky2 = d2; }
 
 	///
 	/// \brief alarm flags for CWS
 	///
-	bool GetProgAlarm() { return ProgAlarm; };
-	bool GetGimbalLockAlarm() { return GimbalLockAlarm; };
+	bool GetProgAlarm() { return ProgAlarm; }
+	bool GetTrackerAlarm() { return TrackerAlarm; }
+	bool GetGimbalLockAlarm() { return GimbalLockAlarm; }
 
 protected:
 
@@ -453,6 +454,7 @@ protected:
 	/// \brief alarm flags for CWS
 	///
 	bool ProgAlarm;
+	bool TrackerAlarm;
 	bool GimbalLockAlarm;
 };
 

--- a/Orbitersdk/samples/ProjectApollo/src_sys/dsky.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_sys/dsky.cpp
@@ -174,11 +174,7 @@ void DSKY::Reset()
 	TempLight = false;
 	GimbalLockLight = false;
 	ProgLight = false;
-	if(agc.vagc.VoltageAlarm != 0){
-		RestartLight = true;
-	}else{
-		RestartLight = false;
-	}
+	RestartLight = false;
 	TrackerLight = false;
 	VelLight = false;
 	AltLight = false;
@@ -370,10 +366,6 @@ void DSKY::ResetPressed()
 {
 	KeyClick();
 	SendKeyCode(18);
-
-	if(agc.vagc.VoltageAlarm != 0){
-		agc.vagc.VoltageAlarm = 0;
-	}
 }
 
 void DSKY::NumberPressed(int n)

--- a/Orbitersdk/samples/ProjectApollo/src_sys/yaAGC/agc_engine.h
+++ b/Orbitersdk/samples/ProjectApollo/src_sys/yaAGC/agc_engine.h
@@ -375,7 +375,6 @@ typedef struct
   unsigned Trap31B:1;           // Enable flag for Trap 31B
   unsigned Trap32:1;            // Enable flag for Trap 32
   uint32_t WarningFilter;       // Current voltage of the AGC warning filter
-  int VoltageAlarm;         // AGC Voltage Alarm
   uint64_t /*unsigned long long */ DownruptTime;	// Time when next DOWNRUPT occurs.
   int NextZ;                    // Next value for the Z register
   int ScalerCounter;            // Counter to keep track of scaler increment timing

--- a/Orbitersdk/samples/ProjectApollo/src_sys/yaAGC/agc_engine_init.c
+++ b/Orbitersdk/samples/ProjectApollo/src_sys/yaAGC/agc_engine_init.c
@@ -228,9 +228,6 @@ agc_engine_init (agc_t * State, const char *RomImage, const char *CoreDump,
   State->ExtraDelay = 0;
   //State->RegQ16 = 0;
 
-  // Reset voltage alarm
-  State->VoltageAlarm = 0;
-
   State->NightWatchman = 0;
   State->NightWatchmanTripped = 0;
   State->RuptLock = 0;


### PR DESCRIPTION
VoltageAlarm was only present on our version and is no longer needed as RestartLight does the same.
PGNS also gets triggered by the TRACKER light.

#551 