### PR TITLE
Make fuel cells' output voltage drop with increasing load.

### DIFF
--- a/Orbitersdk/samples/ProjectApollo/src_csm/satsystems.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_csm/satsystems.cpp
@@ -1431,6 +1431,18 @@ void Saturn::SystemsInternalTimestep(double simdt)
 	//FuelCellH2Manifold[0]->BoilAllAndSetTemp(315);		//Needs to be done using heat exchanger, heated to above 100F
 	//FuelCellH2Manifold[1]->BoilAllAndSetTemp(315);		//Needs to be done using heat exchanger, heated to above 100F
 	//FuelCellH2Manifold[2]->BoilAllAndSetTemp(315);		//Needs to be done using heat exchanger, heated to above 100F
+
+	if (this->systemsState < SATSYSTEMS_GSECONNECTED_1)
+	{
+		//need better solution
+
+		//keep the fuel cells from cooling prior to launch.
+		//this should be done by GSE, not this hacky piece of code
+
+		FuelCells[0]->SetTemp(475.0);
+		FuelCells[1]->SetTemp(475.0);
+		FuelCells[2]->SetTemp(475.0);
+	}
 }
 
 void Saturn::JoystickTimestep()

--- a/Orbitersdk/samples/ProjectApollo/src_csm/satsystems.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_csm/satsystems.cpp
@@ -927,13 +927,6 @@ void Saturn::SystemsTimestep(double simt, double simdt, double mjd) {
 //double *pressequalFlow = (double*)Panelsdk.GetPointerByString("HYDRAULIC:FORWARDHATCHPIPE:FLOW");
 //sprintf(oapiDebugString(), "CSM Tunnel: %lf LM Tunnel: %lf TunnelFlow %lf EqFlow: %lf", (csmtunnelpipe->in->parent->space.Press)*PSI, (csmtunnelpipe->out->parent->space.Press)*PSI, (csmtunnelpipe->flow)*LBH, *pressequalFlow*LBH);
 
-	sprintf(oapiDebugString(), "FC1 %3.3fV/%3.3fA/%3.3fW FC2 %3.3fV/%3.3fA/%3.3fW FC3 %3.3fV/%3.3fA/%3.3fW",
-		FuelCells[0]->Voltage(), FuelCells[0]->Current(), FuelCells[0]->PowerLoad(),
-		FuelCells[1]->Voltage(), FuelCells[1]->Current(), FuelCells[1]->PowerLoad(),
-		FuelCells[2]->Voltage(), FuelCells[2]->Current(), FuelCells[2]->PowerLoad());
-
-	//sprintf(oapiDebugString(), "%0.10f", FuelCells[0]->clogg);
-
 #ifdef _DEBUG
 
 /*		sprintf(oapiDebugString(), "Bus A %3.1fA/%3.1fV, Bus B %3.1fA/%3.1fV, Batt A %3.1fV/%3.1fA/%.3f, Batt B %3.1fV/%.3f Batt C %3.1fV/%.3f Charg %2.1fV/%3.1fA FC1 %3.1fV/%3.1fA", 

--- a/Orbitersdk/samples/ProjectApollo/src_csm/satsystems.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_csm/satsystems.cpp
@@ -927,6 +927,13 @@ void Saturn::SystemsTimestep(double simt, double simdt, double mjd) {
 //double *pressequalFlow = (double*)Panelsdk.GetPointerByString("HYDRAULIC:FORWARDHATCHPIPE:FLOW");
 //sprintf(oapiDebugString(), "CSM Tunnel: %lf LM Tunnel: %lf TunnelFlow %lf EqFlow: %lf", (csmtunnelpipe->in->parent->space.Press)*PSI, (csmtunnelpipe->out->parent->space.Press)*PSI, (csmtunnelpipe->flow)*LBH, *pressequalFlow*LBH);
 
+	sprintf(oapiDebugString(), "FC1 %3.3fV/%3.3fA/%3.3fW FC2 %3.3fV/%3.3fA/%3.3fW FC3 %3.3fV/%3.3fA/%3.3fW",
+		FuelCells[0]->Voltage(), FuelCells[0]->Current(), FuelCells[0]->PowerLoad(),
+		FuelCells[1]->Voltage(), FuelCells[1]->Current(), FuelCells[1]->PowerLoad(),
+		FuelCells[2]->Voltage(), FuelCells[2]->Current(), FuelCells[2]->PowerLoad());
+
+	//sprintf(oapiDebugString(), "%0.10f", FuelCells[0]->clogg);
+
 #ifdef _DEBUG
 
 /*		sprintf(oapiDebugString(), "Bus A %3.1fA/%3.1fV, Bus B %3.1fA/%3.1fV, Batt A %3.1fV/%3.1fA/%.3f, Batt B %3.1fV/%.3f Batt C %3.1fV/%.3f Charg %2.1fV/%3.1fA FC1 %3.1fV/%3.1fA", 

--- a/Orbitersdk/samples/ProjectApollo/src_sys/PanelSDK/Internals/Esystems.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_sys/PanelSDK/Internals/Esystems.cpp
@@ -371,11 +371,10 @@ void FCell::Reaction(double dt, double thrust)
 	h2o_volume.composition[SUBSTANCE_H2O].SetTemp(300.0);
 	h2o_volume.GetQ(); 
 	
-	thermic(heat); //from the reaction
+	thermic(heat); //heat from the reaction
 	H20_waste->Flow(h2o_volume);
 
-	// TSCH clogging disabled
-    Clogging(dt);
+	Clogging(dt); //simulate reactant impurity accumulation
 
 	// TSCH
 	/* sprintf(oapiDebugString(), "m %f Q %f Q/m %f", H2_SRC->parent->space.composition[SUBSTANCE_H2].mass,
@@ -486,19 +485,18 @@ void FCell::UpdateFlow(double dt)
 		Volts = Volts * min(1.0, reaction); //case of reaction problems :-)
 		if (reaction && Volts > 0.0)
 		{
-		//make voltage (and current) drop by 5.2V over 1 day of normal impurity accumulation
+			//make voltage (and current) drop by 5.2V over 1 day of normal impurity accumulation
 
 			Amperes = (power_load / Volts)-(2.25*clogg);
 	
 			loadResistance = (power_load) / (Amperes*Amperes);
 			Volts = Volts * (loadResistance / (loadResistance + outputImpedance))-(5.2*clogg);
 
-			power_load = Amperes * Volts;
+			power_load = Amperes * Volts; //recalculate power_load
 			
 		}
 		else
 		{
-			//status = 2;
 			Amperes = 0;
 		}
 

--- a/Orbitersdk/samples/ProjectApollo/src_sys/PanelSDK/Internals/Esystems.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_sys/PanelSDK/Internals/Esystems.cpp
@@ -260,6 +260,7 @@ FCell::FCell(char *i_name, int i_status, vector3 i_pos, h_Valve *o2, h_Valve *h2
 	H2_SRC = h2;
 	H20_waste = waste;
 
+	outputImpedance = 0.0346667; //ohms
 	SetTemp(475.0); 
 	condenserTemp = 345.0;
 	tempTooLowCount = 0;
@@ -392,6 +393,7 @@ void FCell::UpdateFlow(double dt)
 
 	//first we check the start_handle;
 	double thrust = 0.0;
+	double loadResistance = 0.0;
 	if (start_handle == -1) status = 2; //stopped
 	if (start_handle == 1)	status = 1; //starting
 	if ((purge_handle == 1) && (status == 0 || status == 4)) status = 3; //H2 purging;
@@ -436,7 +438,7 @@ void FCell::UpdateFlow(double dt)
 		}
 
 		if (reaction > 0.3) {
-			Volts = 28.8 * reaction;
+			Volts = 31.0 * reaction;
 			Amperes = (power_load / Volts);
 		} else {
 			Volts = 0;
@@ -465,6 +467,8 @@ void FCell::UpdateFlow(double dt)
 		if (reaction && Volts > 0.0)
 		{
 			Amperes = (power_load / Volts);
+			loadResistance = power_load / (Amperes*Amperes);
+			Volts = Volts * (loadResistance / (loadResistance + outputImpedance));
 		}
 		else
 		{

--- a/Orbitersdk/samples/ProjectApollo/src_sys/PanelSDK/Internals/Esystems.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_sys/PanelSDK/Internals/Esystems.cpp
@@ -479,10 +479,6 @@ void FCell::UpdateFlow(double dt)
 		// sprintf(oapiDebugString(), "thrust %f, log(1+clogg) %f clogg %f", thrust, log(1+clogg), clogg);
 
 		Volts = 31.0; //we are trying to get 31.0V (1V per cell)
-		//if (thrust > 1.0) {	//set voltage to manage overmax loads
-		//	Volts=31.0 / thrust; 
-		//	thrust = 1.0;
-		//}
 
 		Reaction(dt, thrust);
 		running = 0;

--- a/Orbitersdk/samples/ProjectApollo/src_sys/PanelSDK/Internals/Esystems.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_sys/PanelSDK/Internals/Esystems.cpp
@@ -338,7 +338,7 @@ void FCell::Reaction(double dt, double thrust)
 
 	if (status == 4)
 	{
-		O2_flow += __min(0.6 / 7.93665 * dt, O2_maxflow - O2_flow);
+		O2_flow += __min(0.67 / 7.93665 * dt, O2_maxflow - O2_flow);
 		O2_clogging -= O2_clogging * 0.05 * dt; //take approximately 2 minutes to purge
 	}
 

--- a/Orbitersdk/samples/ProjectApollo/src_sys/PanelSDK/Internals/Esystems.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_sys/PanelSDK/Internals/Esystems.cpp
@@ -333,13 +333,13 @@ void FCell::Reaction(double dt, double thrust)
 	if (status == 3)
 	{
 		H2_flow += __min(0.67 / 7.93665 * dt, H2_maxflow - H2_flow);
-		H2_clogging -= H2_clogging * 0.5 * dt; //take approximately 2 minutes to purge
+		H2_clogging -= H2_clogging * 0.05 * dt; //take approximately 2 minutes to purge
 	}
 
 	if (status == 4)
 	{
 		O2_flow += __min(0.6 / 7.93665 * dt, O2_maxflow - O2_flow);
-		O2_clogging -= O2_clogging * 0.5 * dt; //take approximately 2 minutes to purge
+		O2_clogging -= O2_clogging * 0.05 * dt; //take approximately 2 minutes to purge
 	}
 
 	H2_flowPerSecond = H2_flow / dt;

--- a/Orbitersdk/samples/ProjectApollo/src_sys/PanelSDK/Internals/Esystems.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_sys/PanelSDK/Internals/Esystems.cpp
@@ -260,7 +260,6 @@ FCell::FCell(char *i_name, int i_status, vector3 i_pos, h_Valve *o2, h_Valve *h2
 	H20_waste = waste;
 
 	outputImpedance = 0.0346667; //ohms
-	cloggingChange = 0.0;
 
 	H2_clogging = 0.0;
 	O2_clogging = 0.0;
@@ -453,9 +452,9 @@ void FCell::UpdateFlow(double dt)
 		running = 1; //ie. not running
 		break;
 
-	case 1:// starting;
+	case 1:// starting; is this even used? it almost doesnt make physical sense to have it
 		Reaction(dt, 1.0);
-		status = 2;
+		//status = 2; //don't do this, it makes the fuel cells stop
 		if (reaction > 0.96) {
 			status = 0; //started
 			start_handle = 2;
@@ -499,7 +498,7 @@ void FCell::UpdateFlow(double dt)
 		}
 		else
 		{
-			status = 2;
+			//status = 2;
 			Amperes = 0;
 		}
 

--- a/Orbitersdk/samples/ProjectApollo/src_sys/PanelSDK/Internals/Esystems.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_sys/PanelSDK/Internals/Esystems.cpp
@@ -246,7 +246,6 @@ for (int i=0;i<3;i++)
 //----------------------------------- FUEL CELL --------------------------------------
 
 FCell::FCell(char *i_name, int i_status, vector3 i_pos, h_Valve *o2, h_Valve *h2, h_Valve* waste, float r_watts) 
-
 {
 	strcpy(name, i_name);
 	max_stage = 99;
@@ -261,10 +260,21 @@ FCell::FCell(char *i_name, int i_status, vector3 i_pos, h_Valve *o2, h_Valve *h2
 	H20_waste = waste;
 
 	outputImpedance = 0.0346667; //ohms
+	cloggingChange = 0.0;
+
+	H2_clogging = 0.0;
+	O2_clogging = 0.0;
+
+	H2_purity = 0.9994; //set me somewhere else
+	O2_purity = 0.9999; //set me somewhere else
+
+	H2_max_impurities = 0.0504; //nominal impurities after 24hrs //set me somewhere else
+	O2_max_impurities = 0.106; //nominal impurities after 24hrs set me somewhere else
+
 	SetTemp(475.0); 
 	condenserTemp = 345.0;
 	tempTooLowCount = 0;
-	Volts = 28.8;
+	Volts = 31.0;
 	power_load = 600.0; //2 amps is internal impedance		//TSCH Test 
 	max_power = r_watts; //max watts
 	clogg = 0.0; //no clog
@@ -283,7 +293,6 @@ FCell::FCell(char *i_name, int i_status, vector3 i_pos, h_Valve *o2, h_Valve *h2
 }
 
 void FCell::DrawPower(double watts) 
-
 {
 	power_load += watts;
 }
@@ -293,12 +302,16 @@ void FCell::PUNLOAD(double watts) {
 }
 
 void FCell::Reaction(double dt, double thrust) 
-
 {
 	#define H2RATIO 0.1119
 	#define O2RATIO 0.8881
 
 	reactant = dt * max_power * thrust / 2880.0 * 0.2894 ; //grams /second/ 100 amps
+
+	//if (!strcmp(name, "FUELCELL1"))
+	//{
+	//	sprintf(oapiDebugString(), "%0.10f", thrust);
+	//}
 		
 	// get fuel from sources
 	double O2_maxflow = O2_flow = O2_SRC->parent->space.composition[SUBSTANCE_O2].mass;
@@ -317,8 +330,17 @@ void FCell::Reaction(double dt, double thrust)
 	double heat = (O2_flow + H2_flow) * 10000.0;		
 
 	// purging
-	if (status == 3) H2_flow += __min(0.67/7.93665 * dt, H2_maxflow - H2_flow);
-	if (status == 4) O2_flow += __min(0.6/7.93665 * dt, O2_maxflow - O2_flow);
+	if (status == 3)
+	{
+		H2_flow += __min(0.67 / 7.93665 * dt, H2_maxflow - H2_flow);
+		H2_clogging -= H2_clogging * 0.5 * dt; //take approximately 2 minutes to purge
+	}
+
+	if (status == 4)
+	{
+		O2_flow += __min(0.6 / 7.93665 * dt, O2_maxflow - O2_flow);
+		O2_clogging -= O2_clogging * 0.5 * dt; //take approximately 2 minutes to purge
+	}
 
 	H2_flowPerSecond = H2_flow / dt;
 	O2_flowPerSecond = O2_flow / dt;
@@ -354,7 +376,7 @@ void FCell::Reaction(double dt, double thrust)
 	H20_waste->Flow(h2o_volume);
 
 	// TSCH clogging disabled
-    //Clogging(dt);
+    Clogging(dt);
 
 	// TSCH
 	/* sprintf(oapiDebugString(), "m %f Q %f Q/m %f", H2_SRC->parent->space.composition[SUBSTANCE_H2].mass,
@@ -451,16 +473,17 @@ void FCell::UpdateFlow(double dt)
 	case 3: // H2 purging
 	case 4: // O2 purging
 		//---- throttle of the fuel cell [0..1]
-		thrust = power_load / max_power / (1 - log(1 + clogg)); //clogg is preventing normal flow
+		thrust = power_load / max_power;
 
 		// TSCH
 		// sprintf(oapiDebugString(), "thrust %f, log(1+clogg) %f clogg %f", thrust, log(1+clogg), clogg);
 
-		Volts = 28.8; //we are trying to get 28.8V
-		if (thrust > 1.0) {	//set voltage to manage overmax loads
-			Volts= 28.8 / thrust; 
-			thrust = 1.0;
-		}
+		Volts = 31.0; //we are trying to get 28.8V
+		//if (thrust > 1.0) {	//set voltage to manage overmax loads
+		//	Volts=31.0 / thrust; 
+		//	thrust = 1.0;
+		//}
+
 		Reaction(dt, thrust);
 		running = 0;
 		Volts = Volts * min(1.0, reaction); //case of reaction problems :-)
@@ -469,6 +492,11 @@ void FCell::UpdateFlow(double dt)
 			Amperes = (power_load / Volts);
 			loadResistance = power_load / (Amperes*Amperes);
 			Volts = Volts * (loadResistance / (loadResistance + outputImpedance));
+			Volts = Volts - (5.2 * (25 * (O2_clogging / O2_max_impurities) + (H2_clogging / H2_max_impurities))/26.0); //make voltage (and current) drop by 5.2V over 1 day of normal impurity accumulation
+																														//O2 impurities effect voltage drop substantially more than H2(not detectable according to AOH)
+																														//here we're simulating the effect by mahing the O2 clogging effect the voltage drop 25x as much as the H2
+
+			Amperes = (power_load / Volts); //chicken, egg, recalculate (power load (all the drawpower functions) is really just electrical system impedance)
 		}
 		else
 		{
@@ -493,30 +521,35 @@ void FCell::refresh(double dt)
 	//
 }
 
-void FCell::Clogging(double dt) {
+void FCell::Clogging(double dt)
+{
+	H2_clogging += (1 - H2_purity) * H2_flow *dt;
+	O2_clogging += (1 - O2_purity) * O2_flow *dt;
 
-	if (H2_flow) {
-		double change = (O2_flow / (reactant * H2_flow + 0.01) - 0.4) / 100000.0 * dt; //stuff that gets in the way
-		clogg += change;
+	if (H2_clogging < 0)
+	{
+		H2_clogging = 0.0; //cannot be negative	
 	}
-	if (clogg < 0)
-		clogg = 0.0; //cannot get negative, let's be serious;
+
+	if (O2_clogging < 0)
+	{
+		O2_clogging = 0.0; //cannot be negative	
+	}
+		
 }
 
 void FCell::Load(char *line)
-
 {
 	double temp;
-	sscanf (line,"    <FCELL> %s %i %lf %lf %lf", name, &status, &clogg, &temp, &power_load);
+	sscanf (line,"    <FCELL> %s %i %lf %lf %lf %lf", name, &status, &H2_clogging, &O2_clogging, &temp, &power_load);
 	SetTemp(temp);
 	if (status == 0 || status >=3) running = 0;
 }
 
 void FCell::Save(FILEHANDLE scn)
-
 {
 	char cbuf[1000];
-	sprintf (cbuf, "%s %i %0.4f %0.4f %0.4f", name, status, clogg, Temp, power_load);
+	sprintf (cbuf, "%s %i %0.10f %0.10f %0.4f %0.4f", name, status, H2_clogging, O2_clogging, Temp, power_load);
 	oapiWriteScenario_string (scn, "    <FCELL> ", cbuf);
 }
 

--- a/Orbitersdk/samples/ProjectApollo/src_sys/PanelSDK/Internals/Esystems.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_sys/PanelSDK/Internals/Esystems.cpp
@@ -478,7 +478,7 @@ void FCell::UpdateFlow(double dt)
 		// TSCH
 		// sprintf(oapiDebugString(), "thrust %f, log(1+clogg) %f clogg %f", thrust, log(1+clogg), clogg);
 
-		Volts = 31.0; //we are trying to get 28.8V
+		Volts = 31.0; //we are trying to get 31.0V (1V per cell)
 		//if (thrust > 1.0) {	//set voltage to manage overmax loads
 		//	Volts=31.0 / thrust; 
 		//	thrust = 1.0;

--- a/Orbitersdk/samples/ProjectApollo/src_sys/PanelSDK/Internals/Esystems.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_sys/PanelSDK/Internals/Esystems.cpp
@@ -410,8 +410,10 @@ void FCell::UpdateFlow(double dt)
 	}
 
 	//Idle power load to prevent the fuel cells from stopping and cooling too much (has to be fixed at some point)
-	if (power_load < 160.0)
-		power_load = 160.0;
+	//if (power_load < 160.0)
+	//	power_load = 160.0;
+
+
 
 	//first we check the start_handle;
 	double thrust = 0.0;

--- a/Orbitersdk/samples/ProjectApollo/src_sys/PanelSDK/Internals/Esystems.h
+++ b/Orbitersdk/samples/ProjectApollo/src_sys/PanelSDK/Internals/Esystems.h
@@ -243,6 +243,16 @@ public:
 	double condenserTemp;	// condenser exhaust temp, only for display
 	int tempTooLowCount; 
 	double outputImpedance;
+	double cloggingChange;
+
+	double H2_clogging;
+	double O2_clogging;
+
+	double H2_max_impurities;
+	double O2_max_impurities;
+
+	double H2_purity;
+	double O2_purity;
 
 	FCell(char *i_name, int i_status, vector3 i_pos, h_Valve *o2, h_Valve *h2, h_Valve* waste, float r_watts);
 	void DrawPower(double watts);

--- a/Orbitersdk/samples/ProjectApollo/src_sys/PanelSDK/Internals/Esystems.h
+++ b/Orbitersdk/samples/ProjectApollo/src_sys/PanelSDK/Internals/Esystems.h
@@ -243,7 +243,6 @@ public:
 	double condenserTemp;	// condenser exhaust temp, only for display
 	int tempTooLowCount; 
 	double outputImpedance;
-	double cloggingChange;
 
 	double H2_clogging;
 	double O2_clogging;

--- a/Orbitersdk/samples/ProjectApollo/src_sys/PanelSDK/Internals/Esystems.h
+++ b/Orbitersdk/samples/ProjectApollo/src_sys/PanelSDK/Internals/Esystems.h
@@ -242,6 +242,7 @@ public:
 	double running;		//for tb indicators only;they need a float
 	double condenserTemp;	// condenser exhaust temp, only for display
 	int tempTooLowCount; 
+	double outputImpedance;
 
 	FCell(char *i_name, int i_status, vector3 i_pos, h_Valve *o2, h_Valve *h2, h_Valve* waste, float r_watts);
 	void DrawPower(double watts);


### PR DESCRIPTION
Internal resistance is taken as 0.0346667ohms which gives approximately predicted results(27 volts at 1420 watts), and you can get bus under-volt alarms by drawing more than the max on a single cell, as long as you don't draw enough to trip the FC disconnect. Any systems that are expecting a min voltage of exactly 28.8 V may be effected, but if they are set to the specs from the systems handbook they should behave as expected.