### PR TITLE
Visualization of vibration and POGO effects for CSM virtual cockpit

### DIFF
--- a/Orbitersdk/samples/ProjectApollo/src_csm/saturn.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_csm/saturn.cpp
@@ -733,6 +733,10 @@ void Saturn::initSaturn()
 	ViewOffsety = 0;
 	ViewOffsetz = 0;
 
+	NoiseOffsetx = 0;
+	NoiseOffsety = 0;
+	NoiseOffsetz = 0;
+
 	InVC = false;
 	InPanel = false;
 	CheckPanelIdInTimestep = false;
@@ -869,11 +873,11 @@ void Saturn::initSaturn()
 
 	actualFUEL = 0;
 
-	for (i = 0; i < LASTVELOCITYCOUNT; i++) {
-		LastVelocity[i] = _V(0, 0, 0);
-		LastSimt[i] = 0;
-	}
-	LastVelocityFilled = -1;
+	//for (i = 0; i < LASTVELOCITYCOUNT; i++) {
+	//	LastVelocity[i] = _V(0, 0, 0);
+	//	LastSimt[i] = 0;
+	//}
+	//LastVelocityFilled = -1;
 
 	viewpos = SATVIEW_LEFTSEAT;
 
@@ -2642,8 +2646,6 @@ void Saturn::SetStage(int s)
 void Saturn::GenericTimestep(double simt, double simdt, double mjd)
 
 {
-	int i;
-
 	if (GenericFirstTimestep) {
 		//
 		// Do any generic setup.
@@ -2692,24 +2694,158 @@ void Saturn::GenericTimestep(double simt, double simdt, double mjd)
 	}
 #endif // TRACK_TIMESTEPS
 
-	//
-	// Reduce jostle.
-	//
+	// Visualizing vibration
+	// This simulation of the vibration environment in the CM is mostly based on
+	// Saturn V Launch Vehicle Flight Evaluation Report - AS-506, Apollo 11 Mission
+	double dynpress = GetDynPressure();
+	VECTOR3 vAccel, vWeight, vAngAcc;
+	GetForceVector(vAccel);
+	GetWeightVector(vWeight);
+	
+	GetAngularAcc(vAngAcc);
+	vAccel -= vWeight;
+	vAccel /= GetMass();
+	//VECTOR3 ofs;
+	//GetMeshOffset(vcidx, ofs);
+	//ofs.y += 1.0;
+	//vAccel += crossp(ofs, vAngAcc);
+	
+	THRUSTER_HANDLE *tharr;
+	VECTOR3 seatacc = vAccel;
+	double thsum = 0.0;
+	int nth=0;
+	double noiseth = 0.0, noisedp = 0.0, noisefreq = 0.0, latlonratio = 1.0;
+	double pogoamp = 0.0, pogofreq = 0.0;
+	double proplev = GetTotalPropellantMass(), propratio = 0.0;
 
-	ViewOffsetx *= 0.95;
-	ViewOffsety *= 0.95;
-	ViewOffsetz *= 0.95;
+	if (stage <= LAUNCH_STAGE_ONE) {
+		double groundcoeff = max((300.0 - GetAltitude(ALTMODE_GROUND)) / 300.0, 0.0);
+		if (SaturnType == SAT_SATURNV) {
+			nth = 5;
+			tharr = th_1st;
+			propratio = proplev / 2147000.0;
+			noiseth = 0.006*groundcoeff +0.003;
+			noisedp = 5.0e-7;
+			noisefreq = 6.0;
+			latlonratio = 0.2;
 
-	//
-	// And update for acceleration.
-	//
+			pogofreq = 5.6 - 1.4*propratio;
+			if (propratio > 0.9)
+				pogoamp = 2.0 - 18.0*(1.0 - propratio);
+			else if (propratio > 0.5)
+				pogoamp = 0.5;
+			else if (propratio > 0.4)
+				pogoamp = 0.5 + 10.0*(0.5 - propratio);
+			else if (propratio > 0.2)
+				pogoamp = 1.5 - 5.0*(0.4 - propratio);
+			else if (propratio > 0.15)
+				pogoamp = 0.5 + 30.0*(0.2 - propratio);
+			else 
+				pogoamp = 2.0;
+		}
+		else if (SaturnType == SAT_SATURN1B) {
+			nth = 8;
+			tharr = th_1st;
+			propratio = proplev / 413000.0;
+			noiseth = 0.002*groundcoeff + 0.001;
+			noisedp = 5.0e-7;
+			noisefreq = 6.0;
+		}
+	}
+	else if (stage <= LAUNCH_STAGE_TWO_ISTG_JET) {
+		nth = 5;
+		tharr = th_2nd;
+		propratio = proplev / 444000.0;
+		noiseth = 0.0015;
+		noisefreq = 30.0;
+		latlonratio = 0.2;
 
-	double amt = fabs(aHAcc / 25.0) - 0.1;
-	if (amt > 0.25)
-		amt = 0.25;
+		if (StageUnloadState > 0 && StageUnloadState <= 3)
+			pogofreq = 4.2;
+		else {
+			pogofreq = 15.0;
+			if (propratio > 0.98)
+				pogoamp = 2.5*(1.0 - propratio);
+			else if (propratio > 0.9)
+				pogoamp = 0.05;
+			else if (propratio > 0.8)
+				pogoamp = 0.05+9.5*(0.9- propratio);
+			else if (propratio > 0.75)
+				pogoamp = 1.0 - 18.0*(0.8 - propratio);
+		}
+	}
+	else if (stage <= STAGE_ORBIT_SIVB) {
+		nth = 1;
+		tharr = th_3rd;
+		propratio = proplev / 108000.0;
+		noiseth = 0.0075;
+		noisefreq = 30.0;
+	}
+	else if (stage <= CSM_LEM_STAGE) {
+		nth = 1;
+		tharr = th_sps;
+		noisedp = 12.0e-7;
+		noisefreq = 15.0;
+	}
+	else if (stage >= CM_STAGE) {
+		noisedp = 4.0e-7;
+		noiseth = 0.0075;
+		noisefreq = 15.0;
+	}
 
-	if (amt > 0)
-		JostleViewpoint(amt);
+	for (int i = 0; i < nth; i++)
+		thsum += GetThrusterLevel(tharr[i]);
+	
+	if (stage >= LAUNCH_STAGE_ONE &&  stage <= STAGE_ORBIT_SIVB) {
+		if (SaturnType == SAT_SATURNV) {
+			switch (StageUnloadState) {
+			case 0:
+				if (stage== LAUNCH_STAGE_ONE &&  thsum > 4.9)
+					StageUnloadState = 1;
+				break;
+			case 1:
+				if (thsum < 4.8) {
+					StageUnloadTime = MissionTime;
+					StageUnloadState = 2;
+				}
+				break;
+			case 2:
+				pogoamp = 4.0*exp((StageUnloadTime - MissionTime)*0.2);
+				if (thsum < 3.8) {
+					StageUnloadTime = MissionTime;
+					StageUnloadState = 3; //Get ready for a little jolt, fellas!				
+				}
+				break;
+			case 3:
+				pogoamp = 10.0*exp((StageUnloadTime - MissionTime)*1.0);
+				if ((MissionTime- StageUnloadTime) > 5.0) {
+					StageUnloadState = 0;
+					StageUnloadTime = -1;
+				}
+				break;
+			default:
+				break;
+			}
+		}
+		seatacc.z = vAccel.z - pogoamp * sin(6.28*pogofreq*MissionTime);
+	}
+	else if (stage < LAUNCH_STAGE_ONE) {
+		seatacc.x = 0.0;
+		seatacc.y = 0.0;
+		seatacc.z = 9.81;
+	}
+
+	double noiselat = thsum*noiseth + dynpress*noisedp;
+	double noiselong = noiselat*latlonratio;
+	//sprintf(oapiDebugString(), "stage=%d AX=%8.4lf AY=%8.4lf AZ=%8.4lf thsum=%5.2lf dynpress=%9.1lf proplev=%9.0lf propratio=%6.2lf pogofreq=%6.1lf pogoamp=%6.2lf", stage, vAccel.x, vAccel.y, vAccel.z, thsum, dynpress, proplev, propratio, pogofreq, pogoamp);
+
+	if (noiselat > 0.0 || (vAccel.x*vAccel.x+vAccel.y*vAccel.y+ vAccel.z*vAccel.z)>0.01)
+		JostleViewpoint(noiselat, noiselong, noisefreq, simdt, -seatacc.x / 200.0, -seatacc.y / 200.0, -seatacc.z / 300.0 );
+	else {
+		ViewOffsetx *= 0.95;
+		ViewOffsety *= 0.95;
+		ViewOffsetz *= 0.95;
+	}
 
 	//
 	// Velocity calculations
@@ -2720,22 +2856,6 @@ void Saturn::GenericTimestep(double simt, double simdt, double mjd)
 	
 	double aSpeed = length(status.rvel);
 	actualFUEL = ((GetFuelMass() * 100.0) / GetMaxFuelMass());
-
-	// Manage velocity cache
-	for (i = LASTVELOCITYCOUNT - 1; i > 0; i--) {
-		LastVelocity[i] = LastVelocity[i - 1];
-		LastSimt[i] = LastSimt[i - 1];
-	}
-	if (LastVelocityFilled < LASTVELOCITYCOUNT - 1)	LastVelocityFilled++;
-
-	// Store current velocities
-	LastVelocity[0] = status.rvel;
-	LastSimt[0] = simt;
-
-	// Calculate accelerations
-	if (LastVelocityFilled > 0) {
-		aHAcc = (aSpeed - length(LastVelocity[LastVelocityFilled])) / (simt - LastSimt[LastVelocityFilled]);
-	}
 
 	SystemsTimestep(simt, simdt, mjd);
 

--- a/Orbitersdk/samples/ProjectApollo/src_csm/saturn.h
+++ b/Orbitersdk/samples/ProjectApollo/src_csm/saturn.h
@@ -3456,7 +3456,8 @@ protected:
 	// And state that doesn't need to be saved.
 	//
 
-	double aHAcc;
+	boolean StageUnloadState = 0;
+	double StageUnloadTime =-1.0;
 
 	///
 	/// Mesh offset for BPC and LET.
@@ -3473,9 +3474,9 @@ protected:
 	double actualFUEL;
 
 	#define LASTVELOCITYCOUNT 50
-	VECTOR3 LastVelocity[LASTVELOCITYCOUNT];
-	double LastSimt[LASTVELOCITYCOUNT];
-	int LastVelocityFilled;
+	//VECTOR3 LastVelocity[LASTVELOCITYCOUNT];
+	//double LastSimt[LASTVELOCITYCOUNT];
+	//int LastVelocityFilled;
 
 	bool KEY1;
 	bool KEY2;
@@ -4065,7 +4066,7 @@ protected:
 	virtual void CreateStageOne() = 0;
 
 	void StageSix(double simt);
-	void JostleViewpoint(double amount);
+	void JostleViewpoint(double noiselat, double noiselon, double noisefreq, double dt, double accoffsx, double accoffsy, double accoffsz);
 	void UpdatePayloadMass();
 	void GetPayloadName(char *s);
 	void GetApolloName(char *s);
@@ -4329,9 +4330,9 @@ protected:
 	// Random motion.
 	//
 
-	double ViewOffsetx;
-	double ViewOffsety;
-	double ViewOffsetz;
+	double ViewOffsetx, NoiseOffsetx;
+	double ViewOffsety, NoiseOffsety;
+	double ViewOffsetz, NoiseOffsetz;
 
 	//
 	// Save the last view offset.

--- a/Orbitersdk/samples/ProjectApollo/src_csm/saturn.h
+++ b/Orbitersdk/samples/ProjectApollo/src_csm/saturn.h
@@ -3457,7 +3457,7 @@ protected:
 	//
 
 	boolean StageUnloadState = 0;
-	double StageUnloadTime =-1.0;
+	double LastVPAccelTime = -10000.0, StageUnloadTime = -1.0;
 
 	///
 	/// Mesh offset for BPC and LET.
@@ -3472,11 +3472,6 @@ protected:
 	double S4Offset;
 
 	double actualFUEL;
-
-	#define LASTVELOCITYCOUNT 50
-	//VECTOR3 LastVelocity[LASTVELOCITYCOUNT];
-	//double LastSimt[LASTVELOCITYCOUNT];
-	//int LastVelocityFilled;
 
 	bool KEY1;
 	bool KEY2;

--- a/Orbitersdk/samples/ProjectApollo/src_csm/saturnvc.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_csm/saturnvc.cpp
@@ -941,33 +941,40 @@ bool Saturn::clbkVCRedrawEvent (int id, int event, SURFHANDLE surf)
 	//return false;
 }
 
+#define JostleAxis(offset, noiseamp) \
+	j = ((double) ((rand() & 32767) - 16384) * noiseamp*sqdt) / 16384.0; \
+	offset += j; \
+	if(dtmul>1.0) \
+		offset = 0.0; \
+	else \
+		offset = offset-dtmul*offset;
 
-void Saturn::JostleViewpoint(double amount)
+void Saturn::JostleViewpoint(double noiselat, double noiselon, double noisefreq, double dt, double accoffsx, double accoffsy, double accoffsz)
+{	
+	double j, tmpoffs, sqdt=sqrt(dt), dtmul= noisefreq*dt;
+	JostleAxis(NoiseOffsetx, noiselat);
+	JostleAxis(NoiseOffsety, noiselat);
+	JostleAxis(NoiseOffsetz, noiselon);
 
-{
-	double j = ((double) ((rand() & 65535) - 32768) * amount) / 3276800.0;
-	ViewOffsetx += j;
+	ViewOffsetx = NoiseOffsetx + accoffsx;
+	ViewOffsety = NoiseOffsety + accoffsy;
+	ViewOffsetz = NoiseOffsetz + accoffsz;
+	//sprintf(oapiDebugString(), "Offsx:%8.4lf Offsy:%8.4lf Offsz:%8.4lf accoffsz:%8.4lf ", ViewOffsetx, ViewOffsety, ViewOffsetz, accoffsz);
 
-	j = ((double) ((rand() & 65535) - 32768) * amount) / 3276800.0;
-	ViewOffsety += j;
-
-	j = ((double) ((rand() & 65535) - 32768) * amount) / 3276800.0;
-	ViewOffsetz += j;
-
-	if (ViewOffsetx > 0.10)
-		ViewOffsetx = 0.10;
-	if (ViewOffsetx < -0.10)
-		ViewOffsetx = -0.10;
+	if (ViewOffsetx > 0.20)
+		ViewOffsetx = 0.20;
+	if (ViewOffsetx < -0.20)
+		ViewOffsetx = -0.20;
 
 	if (ViewOffsety > 0.10)
 		ViewOffsety = 0.10;
 	if (ViewOffsety < -0.10)
 		ViewOffsety = -0.10;
 
-	if (ViewOffsetz > 0.05)
-		ViewOffsetz = 0.05;
-	if (ViewOffsetz < -0.05)
-		ViewOffsetz = -0.05;
+	if (ViewOffsetz > 0.2)
+		ViewOffsetz = 0.2;
+	if (ViewOffsetz < -0.2)
+		ViewOffsetz = -0.2;
 
 	SetView();
 }
@@ -1140,15 +1147,15 @@ void Saturn::SetView(double offset, bool update_direction)
 	else {
 		switch (viewpos) {
 			case SATVIEW_LEFTSEAT:
-				v = _V(-0.6, 0.9, offset);
+				v = _V(-0.6, 0.9, offset + 0.1);
 				break;
 
 			case SATVIEW_CENTERSEAT:
-				v = _V(0, 0.9, offset);
+				v = _V(0, 0.9, offset + 0.1);
 				break;
 
 			case SATVIEW_RIGHTSEAT:
-				v = _V(0.6, 0.9, offset);
+				v = _V(0.6, 0.9, offset + 0.1);
 				break;
 
 			case SATVIEW_LEFTDOCK:

--- a/Orbitersdk/samples/ProjectApollo/src_saturn/s1c.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_saturn/s1c.cpp
@@ -133,7 +133,7 @@ void S1C::SetS1c()
 
 	SetCameraRotationRange(0.0, 0.0, 0.0, 0.0);
 	SetCameraDefaultDirection(v2);
-	oapiCameraSetCockpitDir(0,0);
+	//oapiCameraSetCockpitDir(0,0); //This thingy messes up the VC camera dir on SIC staging
 	SetCameraOffset(v);
 }
 


### PR DESCRIPTION
Improvement of the originally G-load driven shaking of the virtual cockpit. Now the visualized vibration is a superposition of three factors:
- G-load based offset of the viewpoint (practically head movement due to the G-load caused by thrust and aerodynamic forces)
- Noise-like viewpoint jostling of viewpoint depending on  altitude (reflected shockwaves); on dynamic pressure (aerodynamic vibration) and on thruster activity (engine vibration carried to the cockpit by the structure)
- longitudinal oscillation (POGO effect) depending on the phase of the launch.
The simulation of noise and longitudinal oscillation is based on Mission Reports, Launch Vehicle Flight Evaluation Reports and other sources (the most useful ones were Saturn V Launch Vehicle Flight Evaluation Report - AS-506, Apollo 11 Mission and the formal and informal crew reports in Apollo Flight Journal).

This model of vibration is visual only and has no effect on other parts of the simulation.