### PR TITLE
RTCC: Add initialization for LOI time

### DIFF
--- a/Orbitersdk/samples/ProjectApollo/src_launch/rtcc.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_launch/rtcc.cpp
@@ -67,6 +67,7 @@ RTCC::RTCC()
 	SplashLongitude = 0.0;
 	DeltaV_LVLH = _V(0.0, 0.0, 0.0);
 	calcParams.EI = 0.0;
+	calcParams.LOI = 0.0;
 	calcParams.TEI = 0.0;
 	calcParams.TLI = 0.0;
 	calcParams.R_TLI = _V(0,0,0);


### PR DESCRIPTION
Note: This is a PR for NASSP 7, not NASSP 8.

This little fix prevents issues with the Apollo 8 MCC-1 calculation. The uninitialized variable calcParams.LOI is used as the target time  for LOI. In rare case, like Orbiter Forum user STS experienced on his attempt to fly the mission in real-time, the correct time isn't assigned to the LOI variable and a random time is used as the target. In the case STS experience this was still close, but not equal to 0. The variable got saved as 0 in the scenario though, which made the bug fix itself after reloading the scenario. When you try to fly the mission in one go that is of course undesirable. The bug got fixed for NASSP 8 a long time ago, see: https://github.com/orbiternassp/NASSP/commit/c3f1fa0f685f740d2d65199dfa6ae193a4e12f2f#diff-8d69a445065b349208270ac7f501737c33114daa59b90b3410507976cfbe0d2d

I think this bug is severe enough to make this is a NASSP 7.0.1 release.