### PR TITLE
Add permanent saving of RTCC MFD module data in scenario

### DIFF
--- a/Orbitersdk/samples/ProjectApollo/src_launch/rtcc.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_launch/rtcc.cpp
@@ -1805,10 +1805,6 @@ RTCC::RTCC() :
 	calcParams.SVSTORE1.R = _V(0, 0, 0);
 	calcParams.SVSTORE1.V = _V(0, 0, 0);
 
-	pCSM = pLM = NULL;
-	CSMName[0] = 0;
-	LEMName[0] = 0;
-
 	EZJGMTX1.data[RTCC_REFSMMAT_TYPE_CUR - 1].REFSMMAT = _M(1, 0, 0, 0, 1, 0, 0, 0, 1);
 	EZJGMTX3.data[RTCC_REFSMMAT_TYPE_CUR - 1].REFSMMAT = _M(1, 0, 0, 0, 1, 0, 0, 0, 1);
 	EZJGMTX3.data[RTCC_REFSMMAT_TYPE_AGS - 1].REFSMMAT = _M(1, 0, 0, 0, 1, 0, 0, 0, 1);
@@ -6578,6 +6574,8 @@ void RTCC::SaveState(FILEHANDLE scn) {
 	SAVE_DOUBLE("PZLTRT_DT_Ins_TPI", PZLTRT.DT_Ins_TPI);
 	SAVE_DOUBLE("PZLTRT_PoweredFlightArc", PZLTRT.PoweredFlightArc);
 	SAVE_DOUBLE("PZLTRT_PoweredFlightTime", PZLTRT.PoweredFlightTime);
+	SAVE_DOUBLE("PZLTRT_InsertionHorizontalVelocity", PZLTRT.InsertionHorizontalVelocity);
+	SAVE_DOUBLE("PZLTRT_InsertionRadialVelocity", PZLTRT.InsertionRadialVelocity);
 
 	SAVE_DOUBLE("RZC1RCNS_GLevel", RZC1RCNS.entry.GLevel);
 	SAVE_DOUBLE("RZC1RCNS_GNInitialBank", RZC1RCNS.entry.GNInitialBank);
@@ -6781,14 +6779,6 @@ void RTCC::SaveState(FILEHANDLE scn) {
 	RZJCTTC.SaveState(scn, "RZJCTTC_BEGIN", "RZJCTTC_END");
 	EZGSTMED.SaveState(scn, "EZGSTMED_BEGIN", "EZGSTMED_END");
 
-	if (pCSM)
-	{
-		oapiWriteScenario_string(scn, "RTCCMFD_CSM", pCSM->GetName());
-	}
-	if (pLM)
-	{
-		oapiWriteScenario_string(scn, "RTCCMFD_LM", pLM->GetName());
-	}
 	//MED
 	sprintf(Buffer, "%.2lf %.2lf %.0lf %.0lf %.2lf %.2lf %.2lf",
 		med_k18.HALOI1, med_k18.HPLOI1, med_k18.DVMAXp, med_k18.DVMAXm, med_k18.psi_DS, med_k18.psi_MX, med_k18.psi_MN);
@@ -6952,6 +6942,8 @@ void RTCC::LoadState(FILEHANDLE scn) {
 		LOAD_DOUBLE("PZLTRT_DT_Ins_TPI", PZLTRT.DT_Ins_TPI);
 		LOAD_DOUBLE("PZLTRT_PoweredFlightArc", PZLTRT.PoweredFlightArc);
 		LOAD_DOUBLE("PZLTRT_PoweredFlightTime", PZLTRT.PoweredFlightTime);
+		LOAD_DOUBLE("PZLTRT_InsertionHorizontalVelocity", PZLTRT.InsertionHorizontalVelocity);
+		LOAD_DOUBLE("PZLTRT_InsertionRadialVelocity", PZLTRT.InsertionRadialVelocity);
 
 		LOAD_DOUBLE("RZC1RCNS_GLevel", RZC1RCNS.entry.GLevel);
 		LOAD_DOUBLE("RZC1RCNS_GNInitialBank", RZC1RCNS.entry.GNInitialBank);
@@ -7129,8 +7121,6 @@ void RTCC::LoadState(FILEHANDLE scn) {
 		else if (!strnicmp(line, "EZGSTMED_BEGIN", sizeof("EZGSTMED_BEGIN"))) {
 			EZGSTMED.LoadState(scn, "EZGSTMED_END");
 		}
-		papiReadScenario_string(line, "RTCCMFD_CSM", CSMName);
-		papiReadScenario_string(line, "RTCCMFD_LM", LEMName);
 
 		if (!strnicmp(line, "MED_K18", 7))
 		{
@@ -7171,22 +7161,7 @@ void RTCC::LoadState(FILEHANDLE scn) {
 
 void RTCC::clbkPostCreation()
 {
-	if (CSMName[0])
-	{
-		OBJHANDLE hVessel = oapiGetObjectByName(CSMName);
-		if (hVessel)
-		{
-			pCSM = oapiGetVesselInterface(hVessel);
-		}
-	}
-	if (LEMName[0])
-	{
-		OBJHANDLE hVessel = oapiGetObjectByName(LEMName);
-		if (hVessel)
-		{
-			pLM = oapiGetVesselInterface(hVessel);
-		}
-	}
+	
 }
 
 void RTCC::SetManeuverData(double TIG, VECTOR3 DV)

--- a/Orbitersdk/samples/ProjectApollo/src_launch/rtcc.h
+++ b/Orbitersdk/samples/ProjectApollo/src_launch/rtcc.h
@@ -5340,12 +5340,6 @@ protected:
 	std::ofstream rtccdebug;
 
 public:
-
-	//Vessel pointers to be used exclusively by the RTCC MFD
-	VESSEL *pCSM, *pLM;
-	char CSMName[64];
-	char LEMName[64];
-
 	RTCCSystemParameters SystemParameters;
 	rtcc::RTCCDynamicDisplayData DynamicDisplayData;
 };

--- a/Orbitersdk/samples/ProjectApollo/src_rtccmfd/ARCore.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_rtccmfd/ARCore.cpp
@@ -16,6 +16,7 @@
 #include "ApolloGeneralizedOpticsProgram.h"
 #include "rtcc.h"
 #include "nassputils.h"
+#include "papi.h"
 
 using namespace nassp;
 
@@ -27,9 +28,71 @@ static char debugString[100];
 static char debugStringBuffer[100];
 static char debugWinsock[100];
 
-AR_GCore::AR_GCore(VESSEL* v)
+AR_GlobalData::AR_GlobalData()
 {
 	MissionPlanningActive = false;
+	pCSM = pLM = NULL;
+	CSMName[0] = 0;
+	LEMName[0] = 0;
+	t_LunarLiftoff = 0.0;
+	sxtstardtime = -30.0 * 60.0;
+	t_TPI = 0.0;
+}
+
+void AR_GlobalData::SaveState(FILEHANDLE scn)
+{
+	papiWriteScenario_bool(scn, "MISSIONPLANNINGACTIVE", MissionPlanningActive);
+	if (pCSM)
+	{
+		oapiWriteScenario_string(scn, "RTCCMFD_CSM", pCSM->GetName());
+	}
+	if (pLM)
+	{
+		oapiWriteScenario_string(scn, "RTCCMFD_LM", pLM->GetName());
+	}
+	papiWriteScenario_double(scn, "T_LUNARLIFTOFF", t_LunarLiftoff);
+	papiWriteScenario_double(scn, "SXTSTARDTIME", sxtstardtime);
+	papiWriteScenario_double(scn, "T_TPI", t_TPI);
+}
+
+void AR_GlobalData::LoadState(FILEHANDLE scn)
+{
+	char* line;
+
+	while (oapiReadScenario_nextline(scn, line)) {
+		if (!strnicmp(line, "END", 3))
+			break;
+
+		papiReadScenario_bool(line, "MISSIONPLANNINGACTIVE", MissionPlanningActive);
+		papiReadScenario_string(line, "RTCCMFD_CSM", CSMName);
+		papiReadScenario_string(line, "RTCCMFD_LM", LEMName);
+		papiReadScenario_double(line, "T_LUNARLIFTOFF", t_LunarLiftoff);
+		papiReadScenario_double(line, "SXTSTARDTIME", sxtstardtime);
+		papiReadScenario_double(line, "T_TPI", t_TPI);
+	}
+
+	if (CSMName[0])
+	{
+		OBJHANDLE hVessel = oapiGetObjectByName(CSMName);
+		if (hVessel)
+		{
+			pCSM = oapiGetVesselInterface(hVessel);
+		}
+	}
+	if (LEMName[0])
+	{
+		OBJHANDLE hVessel = oapiGetObjectByName(LEMName);
+		if (hVessel)
+		{
+			pLM = oapiGetVesselInterface(hVessel);
+		}
+	}
+}
+
+AR_GCore::AR_GCore(AR_GlobalData* GD, VESSEL* v)
+{
+	this->GD = GD;
+
 	mptInitError = 0;
 
 	AGOP_Option = 1;
@@ -177,8 +240,6 @@ AR_GCore::AR_GCore(VESSEL* v)
 	PDAP_A_min = 0.0;
 	PDAP_A_max = 0.0;
 	PDAP_ErrorCode = 0;
-
-	t_TPI = 0.0;
 
 	int mission = 0;
 
@@ -521,11 +582,11 @@ void AR_GCore::MPTMassUpdate()
 
 	if (rtcc->med_m49.Table == RTCC_MPT_CSM)
 	{
-		v = rtcc->pCSM;
+		v = GD->pCSM;
 	}
 	else
 	{
-		v = rtcc->pLM;
+		v = GD->pLM;
 	}
 
 	if (v == NULL) return;
@@ -594,9 +655,10 @@ void AR_GCore::DFLBackgroundSlide(oapi::Sketchpad *skp, DWORD W, DWORD WOFF, DWO
 	BackgroundSlides.Print(skp, W, WOFF, H, HOFF, display);
 }
 
-ARCore::ARCore(VESSEL* v, AR_GCore* gcin)
+ARCore::ARCore(VESSEL* v, AR_GCore* gcin, AR_GlobalData* gdin)
 {
 	GC = gcin;
+	GD = gdin;
 
 	CDHtimemode = 0;
 
@@ -610,16 +672,16 @@ ARCore::ARCore(VESSEL* v, AR_GCore* gcin)
 
 	vesselisdocked = false;
 	//For now, CSM or LM being docked will set this flag
-	if (GC->rtcc->pCSM)
+	if (GD->pCSM)
 	{
-		if (GC->rtcc->pCSM->DockingStatus(0) == 1)
+		if (GD->pCSM->DockingStatus(0) == 1)
 		{
 			vesselisdocked = true;
 		}
 	}
-	if (GC->rtcc->pLM)
+	if (GD->pLM)
 	{
-		if (GC->rtcc->pLM->DockingStatus(0) == 1)
+		if (GD->pLM->DockingStatus(0) == 1)
 		{
 			vesselisdocked = true;
 		}
@@ -649,11 +711,11 @@ ARCore::ARCore(VESSEL* v, AR_GCore* gcin)
 	g_Data.uplinkBufferSimt = 0;
 	g_Data.connStatus = 0;
 	g_Data.uplinkState = 0;
-	if (GC->rtcc->pLM)
+	if (GD->pLM)
 	{
-		if (utils::IsVessel(GC->rtcc->pLM, utils::LEM))
+		if (utils::IsVessel(GD->pLM, utils::LEM))
 		{
-			LEM *lem = (LEM *)GC->rtcc->pLM;
+			LEM *lem = (LEM *)GD->pLM;
 			if (lem->GetStage() < 2)
 			{
 				lemdescentstage = true;
@@ -688,7 +750,6 @@ ARCore::ARCore(VESSEL* v, AR_GCore* gcin)
 	HeadsUp = false;
 
 	manpadenginetype = RTCC_ENGINETYPE_CSMSPS;
-	sxtstardtime = -30.0*60.0;
 	manpad_ullage_dt = 0.0;
 	manpad_ullage_opt = true;
 	manpad_pref_GDC_stars = 0;
@@ -713,9 +774,6 @@ ARCore::ARCore(VESSEL* v, AR_GCore* gcin)
 	iuvessel = NULL;
 	TLCCSolGood = true;
 
-	landingzone = 0;
-	entryprecision = -1;
-
 	subThreadMode = 0;
 	subThreadStatus = DONE;
 	IsCSMCalculation = false;
@@ -736,7 +794,6 @@ ARCore::ARCore(VESSEL* v, AR_GCore* gcin)
 	TMStepSize = 100.0*0.3048;
 	TMAlt = 0.0;
 
-	t_LunarLiftoff = 0.0;
 	LAP_Phase = 0.0;
 	LAP_CR = 0.0;
 	AscentPADVersion = 0;
@@ -862,7 +919,7 @@ void ARCore::LunarLiftoffCalc()
 
 void ARCore::EntryUpdateCalc()
 {
-	VESSEL *v = GC->rtcc->pCSM;
+	VESSEL *v = GD->pCSM;
 
 	if (v == NULL) return;
 
@@ -1105,11 +1162,11 @@ void ARCore::DAPPADCalc(bool IsCSM)
 
 	if (IsCSM)
 	{
-		v = GC->rtcc->pCSM;
+		v = GD->pCSM;
 	}
 	else
 	{
-		v = GC->rtcc->pLM;
+		v = GD->pLM;
 	}
 
 	if (v == NULL) return;
@@ -1225,7 +1282,7 @@ void ARCore::GetStateVectorFromIU()
 	VESSEL *v;
 
 	//For now only Saturn class
-	v = GC->rtcc->pCSM;
+	v = GD->pCSM;
 
 	if (v == NULL) return;
 
@@ -1293,7 +1350,7 @@ void ARCore::GetStateVectorFromIU()
 
 void ARCore::GetStateVectorsFromAGS()
 {
-	VESSEL *v = GC->rtcc->pLM;
+	VESSEL *v = GD->pLM;
 	//LM vessel set?
 	if (v == NULL) return;
 	//Is vehicle a LM?
@@ -1388,11 +1445,11 @@ agc_t* ARCore::GetAGCPointer(bool cmc) const
 
 	if (cmc)
 	{
-		v = GC->rtcc->pCSM;
+		v = GD->pCSM;
 	}
 	else
 	{
-		v = GC->rtcc->pLM;
+		v = GD->pLM;
 	}
 
 	if (v == NULL) return NULL;
@@ -1534,11 +1591,11 @@ void ARCore::NavCheckPAD(bool IsCSM)
 
 	if (IsCSM)
 	{
-		v = GC->rtcc->pCSM;
+		v = GD->pCSM;
 	}
 	else
 	{
-		v = GC->rtcc->pLM;
+		v = GD->pLM;
 	}
 
 	if (v == NULL) return;
@@ -1550,7 +1607,7 @@ void ARCore::NavCheckPAD(bool IsCSM)
 
 void ARCore::LandingSiteUpdate()
 {
-	VESSEL *v = GC->rtcc->pLM;
+	VESSEL *v = GD->pLM;
 
 	if (v == NULL) return;
 
@@ -1609,17 +1666,17 @@ void ARCore::StateVectorCalc(int type)
 	if (type == 0 || type == 21)
 	{
 		mptveh = RTCC_MPT_CSM;
-		v = GC->rtcc->pCSM;
+		v = GD->pCSM;
 	}
 	else
 	{
 		mptveh = RTCC_MPT_LM;
-		v = GC->rtcc->pLM;
+		v = GD->pLM;
 	}
 
 	//Check on v not being NULL is already in the calling function!
 
-	if (GC->MissionPlanningActive)
+	if (GD->MissionPlanningActive)
 	{
 		double get;
 		if (SVDesiredGET < 0)
@@ -1657,11 +1714,11 @@ void ARCore::AGSStateVectorCalc(bool IsCSM)
 
 	if (IsCSM)
 	{
-		v = GC->rtcc->pCSM;
+		v = GD->pCSM;
 	}
 	else
 	{
-		v = GC->rtcc->pLM;
+		v = GD->pLM;
 	}
 
 	if (v == NULL) return;
@@ -2393,11 +2450,11 @@ void ARCore::VecPointCalc(bool IsCSM)
 		VESSEL *v;
 		if (IsCSM)
 		{
-			v = GC->rtcc->pCSM;
+			v = GD->pCSM;
 		}
 		else
 		{
-			v = GC->rtcc->pLM;
+			v = GD->pLM;
 		}
 
 		if (v == NULL) return;
@@ -2793,7 +2850,7 @@ int ARCore::subThread()
 			mptveh = RTCC_MPT_LM;
 		}
 
-		if (GC->MissionPlanningActive)
+		if (GD->MissionPlanningActive)
 		{
 			if (REFSMMATopt == 0)
 			{
@@ -2872,19 +2929,19 @@ int ARCore::subThread()
 		}
 
 		//For LS REFSMMAT use CSM vessel
-		if (GC->MissionPlanningActive == false && REFSMMATopt == 5)
+		if (GD->MissionPlanningActive == false && REFSMMATopt == 5)
 		{
-			opt.vessel = GC->rtcc->pCSM;
+			opt.vessel = GD->pCSM;
 		}
 		else
 		{
 			if (IsCSMCalculation)
 			{
-				opt.vessel = GC->rtcc->pCSM;
+				opt.vessel = GD->pCSM;
 			}
 			else
 			{
-				opt.vessel = GC->rtcc->pLM;
+				opt.vessel = GD->pLM;
 			}
 		}
 
@@ -2929,9 +2986,9 @@ int ARCore::subThread()
 		}
 
 		opt.IMUAngles = VECangles;
-		opt.csmlmdocked = !GC->MissionPlanningActive && vesselisdocked;
+		opt.csmlmdocked = !GD->MissionPlanningActive && vesselisdocked;
 
-		if (GC->MissionPlanningActive && GC->rtcc->MPTHasManeuvers(mptveh))
+		if (GD->MissionPlanningActive && GC->rtcc->MPTHasManeuvers(mptveh))
 		{
 			opt.useSV = true;
 
@@ -3038,7 +3095,7 @@ int ARCore::subThread()
 	break;
 	case 6: //TPI PAD
 	{
-		if (GC->rtcc->pCSM == NULL || GC->rtcc->pLM == NULL)
+		if (GD->pCSM == NULL || GD->pLM == NULL)
 		{
 			Result = DONE;
 			break;
@@ -3048,9 +3105,9 @@ int ARCore::subThread()
 
 		opt.dV_LVLH = dV_LVLH;
 		opt.TIG = P30TIG;
-		opt.sv_A = GC->rtcc->StateVectorCalcEphem(GC->rtcc->pCSM);
-		opt.sv_P = GC->rtcc->StateVectorCalcEphem(GC->rtcc->pLM);
-		opt.mass = GC->rtcc->pCSM->GetMass();
+		opt.sv_A = GC->rtcc->StateVectorCalcEphem(GD->pCSM);
+		opt.sv_P = GC->rtcc->StateVectorCalcEphem(GD->pLM);
+		opt.mass = GD->pCSM->GetMass();
 
 		GC->rtcc->AP7TPIPAD(opt, GC->TPI_PAD);
 
@@ -3059,13 +3116,13 @@ int ARCore::subThread()
 	break;
 	case 7:	//Return to Earth
 	{
-		if (GC->MissionPlanningActive)
+		if (GD->MissionPlanningActive)
 		{
 			GC->rtcc->GMGMED("F80;");
 		}
 		else
 		{
-			VESSEL *v = GC->rtcc->pCSM;
+			VESSEL *v = GD->pCSM;
 
 			if (v == NULL)
 			{
@@ -3079,7 +3136,7 @@ int ARCore::subThread()
 			//This doesn't work in debug mode (with only RTCC MFD and MCC modules build), so below are some fake masses
 			GC->rtcc->MPTMassUpdate(v, med1, med2, med3);
 
-			GC->rtcc->VEHDATABUF.csmmass = med1.CSMWT;//GC->rtcc->pCSM->GetMass();//
+			GC->rtcc->VEHDATABUF.csmmass = med1.CSMWT;//GD->pCSM->GetMass();//
 			GC->rtcc->VEHDATABUF.lmascmass = med1.LMASCWT;//0.0;10000.0*0.453;//
 			GC->rtcc->VEHDATABUF.lmdscmass = med1.LMWT - med1.LMASCWT;//0.0;25000.0*0.453;//
 			GC->rtcc->VEHDATABUF.sv = GC->rtcc->StateVectorCalcEphem(v);
@@ -3093,16 +3150,16 @@ int ARCore::subThread()
 	break;
 	case 8: //TLI PAD
 	{
-		if (GC->rtcc->pCSM == NULL)
+		if (GD->pCSM == NULL)
 		{
 			Result = DONE;
 			break;
 		}
 
 		LVDCSV *lvdc = NULL;
-		if (utils::IsVessel(GC->rtcc->pCSM, utils::SaturnV))
+		if (utils::IsVessel(GD->pCSM, utils::SaturnV))
 		{
-			SaturnV * SatV = (SaturnV *)GC->rtcc->pCSM;
+			SaturnV * SatV = (SaturnV *)GD->pCSM;
 			if (SatV->iu)
 			{
 				lvdc = (LVDCSV*)SatV->iu->GetLVDC();
@@ -3116,7 +3173,7 @@ int ARCore::subThread()
 
 		TLIPADOpt opt;
 
-		opt.ConfigMass = GC->rtcc->pCSM->GetMass();
+		opt.ConfigMass = GD->pCSM->GetMass();
 		if (lvdc->first_op)
 		{
 			opt.InjOpp = 1;
@@ -3127,7 +3184,7 @@ int ARCore::subThread()
 		}
 		opt.REFSMMAT= GC->rtcc->EZJGMTX1.data[0].REFSMMAT;
 		opt.SeparationAttitude = lvdc->XLunarAttitude;
-		opt.sv0 = GC->rtcc->StateVectorCalcEphem(GC->rtcc->pCSM);
+		opt.sv0 = GC->rtcc->StateVectorCalcEphem(GD->pCSM);
 		opt.StudyAid = TLIPAD_StudyAid;
 
 		GC->rtcc->TLI_PAD(opt, GC->tlipad);
@@ -3140,7 +3197,7 @@ int ARCore::subThread()
 		EphemerisData sv_A;
 		PLAWDTOutput WeightsTable;
 
-		if (GC->MissionPlanningActive)
+		if (GD->MissionPlanningActive)
 		{
 			//Get pointer to MPT maneuver
 			MissionPlanTable *mpt = GC->rtcc->GetMPTPointer(ManPADMPT);
@@ -3249,11 +3306,11 @@ int ARCore::subThread()
 			VESSEL *v;
 			if (IsCSMCalculation)
 			{
-				v = GC->rtcc->pCSM;
+				v = GD->pCSM;
 			}
 			else
 			{
-				v = GC->rtcc->pLM;
+				v = GD->pLM;
 			}
 
 			if (v == NULL)
@@ -3275,7 +3332,7 @@ int ARCore::subThread()
 			opt.enginetype = manpadenginetype;
 			opt.HeadsUp = HeadsUp;
 			opt.REFSMMAT = GC->rtcc->EZJGMTX1.data[0].REFSMMAT;
-			opt.sxtstardtime = sxtstardtime;
+			opt.sxtstardtime = GD->sxtstardtime;
 			opt.RV_MCC = sv_A;
 			opt.WeightsTable = WeightsTable;
 			opt.UllageDT = manpad_ullage_dt;
@@ -3293,7 +3350,7 @@ int ARCore::subThread()
 			opt.enginetype = manpadenginetype;
 			opt.HeadsUp = HeadsUp;
 			opt.REFSMMAT = GC->rtcc->EZJGMTX3.data[0].REFSMMAT;
-			opt.sxtstardtime = sxtstardtime;
+			opt.sxtstardtime = GD->sxtstardtime;
 			opt.RV_MCC = sv_A;
 			opt.WeightsTable = WeightsTable;
 
@@ -3316,7 +3373,7 @@ int ARCore::subThread()
 			break;
 		}
 		//Get LM weight
-		if (GC->MissionPlanningActive)
+		if (GD->MissionPlanningActive)
 		{
 			PLAWDTInput pin;
 			PLAWDTOutput pout;
@@ -3330,9 +3387,9 @@ int ARCore::subThread()
 		}
 		else
 		{
-			if (GC->rtcc->pLM)
+			if (GD->pLM)
 			{
-				W_LM = GC->rtcc->pLM->GetMass();
+				W_LM = GD->pLM->GetMass();
 			}
 			else
 			{
@@ -3351,11 +3408,11 @@ int ARCore::subThread()
 
 		if (GC->rtcc->EZETVMED.SpaceDigVehID == RTCC_MPT_CSM)
 		{
-			v = GC->rtcc->pCSM;
+			v = GD->pCSM;
 		}
 		else
 		{
-			v = GC->rtcc->pLM;
+			v = GD->pLM;
 		}
 
 		if (v == NULL)
@@ -3375,7 +3432,7 @@ int ARCore::subThread()
 		EphemerisData state;
 		PLAWDTOutput WeightsTable;
 
-		if (GC->MissionPlanningActive)
+		if (GD->MissionPlanningActive)
 		{
 			GC->rtcc->TranslunarInjectionProcessor(true);
 		}
@@ -3401,7 +3458,7 @@ int ARCore::subThread()
 		LLTPOpt opt;
 		EphemerisData sv_CSM;
 
-		if (GC->MissionPlanningActive)
+		if (GD->MissionPlanningActive)
 		{
 			if (GC->rtcc->EMSFFV(GC->rtcc->GMTfromGET(GC->rtcc->med_k50.GETV), RTCC_MPT_CSM, sv_CSM))
 			{
@@ -3412,7 +3469,7 @@ int ARCore::subThread()
 		}
 		else
 		{
-			VESSEL *v = GC->rtcc->pCSM;
+			VESSEL *v = GD->pCSM;
 
 			if (v == NULL)
 			{
@@ -3440,7 +3497,7 @@ int ARCore::subThread()
 
 		if (GC->rtcc->LunarLiftoffTimePredictionDT(opt, GC->rtcc->PZLLTT))
 		{
-			t_LunarLiftoff = GC->rtcc->PZLLTT.GETLOR;
+			GD->t_LunarLiftoff = GC->rtcc->PZLLTT.GETLOR;
 			GC->rtcc->PZLTRT.InsertionHorizontalVelocity = GC->rtcc->PZLLTT.VH;
 		}
 
@@ -3460,7 +3517,7 @@ int ARCore::subThread()
 			break;
 		}
 		//Get CSM and LM masses
-		if (GC->MissionPlanningActive)
+		if (GD->MissionPlanningActive)
 		{
 			PLAWDTInput pin;
 			PLAWDTOutput pout;
@@ -3473,7 +3530,7 @@ int ARCore::subThread()
 		}
 		else
 		{
-			VESSEL *v = GC->rtcc->pCSM;
+			VESSEL *v = GD->pCSM;
 
 			if (v == NULL)
 			{
@@ -3585,7 +3642,7 @@ int ARCore::subThread()
 		PDIPADOpt opt;
 		AP11PDIPAD temppdipad;
 
-		if (GC->MissionPlanningActive)
+		if (GD->MissionPlanningActive)
 		{
 			std::string StaID;
 			double GMTV;
@@ -3601,13 +3658,13 @@ int ARCore::subThread()
 		}
 		else
 		{
-			if (GC->rtcc->pLM == NULL)
+			if (GD->pLM == NULL)
 			{
 				Result = DONE;
 				break;
 			}
 
-			opt.sv0 = GC->rtcc->StateVectorCalcDataBlock(GC->rtcc->pLM);
+			opt.sv0 = GC->rtcc->StateVectorCalcDataBlock(GD->pLM);
 		}
 
 		opt.direct = true;
@@ -3631,7 +3688,7 @@ int ARCore::subThread()
 		EphemerisData sv;
 		double CSMmass;
 
-		if (GC->MissionPlanningActive)
+		if (GD->MissionPlanningActive)
 		{
 			double GMT = GC->rtcc->GMTfromGET(GC->rtcc->RZJCTTC.R32_GETI);
 			int err = GC->rtcc->EMSFFV(GMT, RTCC_MPT_CSM, sv);
@@ -3650,7 +3707,7 @@ int ARCore::subThread()
 		}
 		else
 		{
-			VESSEL *v = GC->rtcc->pCSM;
+			VESSEL *v = GD->pCSM;
 
 			if (v == NULL)
 			{
@@ -3698,7 +3755,7 @@ int ARCore::subThread()
 			GMT = GC->rtcc->GMTfromGET(GC->rtcc->med_k10.MLDTime);
 		}
 
-		if (GC->MissionPlanningActive)
+		if (GD->MissionPlanningActive)
 		{
 			VehicleDataBlock sv_chaser, sv_target;
 			std::string StaID;
@@ -3732,14 +3789,14 @@ int ARCore::subThread()
 		}
 		else
 		{
-			if (GC->rtcc->pCSM == NULL || GC->rtcc->pLM == NULL)
+			if (GD->pCSM == NULL || GD->pLM == NULL)
 			{
 				Result = DONE;
 				break;
 			}
 
-			opt.sv_CSM = GC->rtcc->StateVectorCalcEphem(GC->rtcc->pCSM);
-			opt.sv_LM = GC->rtcc->StateVectorCalcEphem(GC->rtcc->pLM);
+			opt.sv_CSM = GC->rtcc->StateVectorCalcEphem(GD->pCSM);
+			opt.sv_LM = GC->rtcc->StateVectorCalcEphem(GD->pLM);
 
 			//Coast to threshold time
 			opt.sv_CSM = GC->rtcc->coast(opt.sv_CSM, GMT - opt.sv_CSM.GMT);
@@ -3809,9 +3866,9 @@ int ARCore::subThread()
 		RTCC::LunarAscentProcessorInputs asc_in;
 		RTCC::LunarAscentProcessorOutputs asc_out;
 
-		if (GC->MissionPlanningActive)
+		if (GD->MissionPlanningActive)
 		{
-			double GMT = GC->rtcc->GMTfromGET(t_LunarLiftoff);
+			double GMT = GC->rtcc->GMTfromGET(GD->t_LunarLiftoff);
 			EphemerisData EPHEM;
 			if (GC->rtcc->EMSFFV(GMT, RTCC_MPT_CSM, EPHEM))
 			{
@@ -3831,18 +3888,18 @@ int ARCore::subThread()
 		}
 		else
 		{
-			if (GC->rtcc->pCSM == NULL || GC->rtcc->pLM == NULL)
+			if (GD->pCSM == NULL || GD->pLM == NULL)
 			{
 				Result = DONE;
 				break;
 			}
-			asc_in.sv_CSM = GC->rtcc->StateVectorCalcEphem(GC->rtcc->pCSM);
-			LEM *l = (LEM *)GC->rtcc->pLM;
+			asc_in.sv_CSM = GC->rtcc->StateVectorCalcEphem(GD->pCSM);
+			LEM *l = (LEM *)GD->pLM;
 			asc_in.m0 = l->GetAscentStageMass();
 		}
 
 		asc_in.R_LS = OrbMech::r_from_latlong(GC->rtcc->BZLAND.lat[RTCC_LMPOS_BEST], GC->rtcc->BZLAND.lng[RTCC_LMPOS_BEST], GC->rtcc->BZLAND.rad[RTCC_LMPOS_BEST]);
-		asc_in.t_liftoff = GC->rtcc->GMTfromGET(t_LunarLiftoff);
+		asc_in.t_liftoff = GC->rtcc->GMTfromGET(GD->t_LunarLiftoff);
 		asc_in.v_LH = GC->rtcc->PZLTRT.InsertionHorizontalVelocity;
 		asc_in.v_LV = GC->rtcc->PZLTRT.InsertionRadialVelocity;
 
@@ -3851,7 +3908,7 @@ int ARCore::subThread()
 		GC->rtcc->PZLTRT.PoweredFlightArc = asc_out.theta;
 		GC->rtcc->PZLTRT.PoweredFlightTime = asc_out.dt_asc;
 
-		GC->rtcc->JZLAI.t_launch = t_LunarLiftoff;
+		GC->rtcc->JZLAI.t_launch = GD->t_LunarLiftoff;
 		GC->rtcc->JZLAI.R_D = 60000.0*0.3048;
 		GC->rtcc->JZLAI.Y_D = 0.0;
 		GC->rtcc->JZLAI.R_D_dot = GC->rtcc->PZLTRT.InsertionRadialVelocity;
@@ -3870,7 +3927,7 @@ int ARCore::subThread()
 	{
 		//TBD: MPT compatibility
 
-		if (GC->rtcc->pCSM == NULL || GC->rtcc->pLM == NULL)
+		if (GD->pCSM == NULL || GD->pLM == NULL)
 		{
 			Result = DONE;
 			break;
@@ -3879,12 +3936,12 @@ int ARCore::subThread()
 		ASCPADOpt opt;
 		EphemerisData sv_CSM;
 
-		sv_CSM = GC->rtcc->StateVectorCalcEphem(GC->rtcc->pCSM);
+		sv_CSM = GC->rtcc->StateVectorCalcEphem(GD->pCSM);
 
-		opt.Rot_VL = OrbMech::GetVesselToLocalRotMatrix(GC->rtcc->pLM);
+		opt.Rot_VL = OrbMech::GetVesselToLocalRotMatrix(GD->pLM);
 		opt.R_LS = OrbMech::r_from_latlong(GC->rtcc->BZLAND.lat[RTCC_LMPOS_BEST], GC->rtcc->BZLAND.lng[RTCC_LMPOS_BEST], GC->rtcc->BZLAND.rad[RTCC_LMPOS_BEST]);
 		opt.sv_CSM = sv_CSM;
-		opt.TIG = t_LunarLiftoff;
+		opt.TIG = GD->t_LunarLiftoff;
 		opt.v_LH = GC->rtcc->PZLTRT.InsertionHorizontalVelocity;
 		opt.v_LV = GC->rtcc->PZLTRT.InsertionRadialVelocity;
 
@@ -3899,7 +3956,7 @@ int ARCore::subThread()
 		PDAPResults res;
 		VehicleDataBlock sv_LM, sv_CSM;
 
-		if (GC->MissionPlanningActive)
+		if (GD->MissionPlanningActive)
 		{
 			std::string StaID;
 			double GMT;
@@ -3936,14 +3993,14 @@ int ARCore::subThread()
 		}
 		else
 		{
-			if (GC->rtcc->pCSM == NULL || GC->rtcc->pLM == NULL)
+			if (GD->pCSM == NULL || GD->pLM == NULL)
 			{
 				Result = DONE;
 				break;
 			}
 
-			sv_LM = GC->rtcc->StateVectorCalcDataBlock(GC->rtcc->pLM);
-			sv_CSM = GC->rtcc->StateVectorCalcDataBlock(GC->rtcc->pCSM);
+			sv_LM = GC->rtcc->StateVectorCalcDataBlock(GD->pLM);
+			sv_CSM = GC->rtcc->StateVectorCalcDataBlock(GD->pCSM);
 		}
 
 		//Copy over the general settings
@@ -4062,7 +4119,7 @@ int ARCore::subThread()
 	case 23: //Calculate TPI times
 	{
 		VehicleDataBlock sv0;
-		if (GC->MissionPlanningActive)
+		if (GD->MissionPlanningActive)
 		{
 			std::string StaID;
 			if (GC->rtcc->PMSVEC(Rendezvous_Target_Table, true, GC->rtcc->GMTfromGET(t_TPIguess), "", sv0, StaID))
@@ -4081,7 +4138,7 @@ int ARCore::subThread()
 			sv0 = GC->rtcc->StateVectorCalcDataBlock(Rendezvous_Target);
 		}
 		SV sv1 = GC->rtcc->ConvertEphemDatatoSV(sv0.sv, sv0.Weight);
-		GC->t_TPI = GC->rtcc->CalculateTPITimes(sv1, TPI_Mode, t_TPIguess, dt_TPI_sunrise);
+		GD->t_TPI = GC->rtcc->CalculateTPITimes(sv1, TPI_Mode, t_TPIguess, dt_TPI_sunrise);
 
 		Result = DONE;
 	}
@@ -4200,7 +4257,7 @@ int ARCore::subThread()
 	break;
 	case 31: //Entry PAD
 	{
-		VESSEL *v = GC->rtcc->pCSM;
+		VESSEL *v = GD->pCSM;
 
 		if (v == NULL)
 		{
@@ -4250,7 +4307,7 @@ int ARCore::subThread()
 		{
 			LunarEntryPADOpt opt;
 
-			if (GC->MissionPlanningActive)
+			if (GD->MissionPlanningActive)
 			{
 				VehicleDataBlock sv0;
 				if (GC->rtcc->NewMPTTrajectory(RTCC_MPT_CSM, sv0))
@@ -4292,7 +4349,7 @@ int ARCore::subThread()
 			gmt = GC->rtcc->GMTfromGET(mapUpdateGET);
 		}
 
-		if (GC->MissionPlanningActive)
+		if (GD->MissionPlanningActive)
 		{
 			if (GC->rtcc->EMSFFV(gmt, RTCC_MPT_CSM, sv0))
 			{
@@ -4306,11 +4363,11 @@ int ARCore::subThread()
 
 			if (IsCSMCalculation)
 			{
-				v = GC->rtcc->pCSM;
+				v = GD->pCSM;
 			}
 			else
 			{
-				v = GC->rtcc->pLM;
+				v = GD->pLM;
 			}
 			if (v == NULL)
 			{
@@ -4378,7 +4435,7 @@ int ARCore::subThread()
 			gmt = GC->rtcc->GMTfromGET(get);
 		}
 
-		if (GC->MissionPlanningActive)
+		if (GD->MissionPlanningActive)
 		{
 			EphemerisData sv;
 			if (GC->rtcc->EMSFFV(gmt, RTCC_MPT_CSM, sv0))
@@ -4389,7 +4446,7 @@ int ARCore::subThread()
 		}
 		else
 		{
-			VESSEL *v = GC->rtcc->pCSM;
+			VESSEL *v = GD->pCSM;
 
 			if (v == NULL)
 			{
@@ -4420,7 +4477,7 @@ int ARCore::subThread()
 	break;
 	case 35: //AGS Clock Sync
 	{
-		VESSEL *v = GC->rtcc->pLM;
+		VESSEL *v = GD->pLM;
 
 		if (v == NULL || utils::IsVessel(v, utils::LEM) == false)
 		{
@@ -4459,7 +4516,7 @@ int ARCore::subThread()
 		gmt_min = gmt_guess;
 		gmt_max = gmt_guess + 2.75*60.0*60.0;
 
-		if (GC->MissionPlanningActive)
+		if (GD->MissionPlanningActive)
 		{
 			unsigned int NumVec;
 			int TUP;
@@ -4481,11 +4538,11 @@ int ARCore::subThread()
 
 			if (GC->rtcc->RZJCTTC.R20_VEH == RTCC_MPT_CSM)
 			{
-				v = GC->rtcc->pCSM;
+				v = GD->pCSM;
 			}
 			else
 			{
-				v = GC->rtcc->pLM;
+				v = GD->pLM;
 			}
 			if (v == NULL)
 			{
@@ -4526,7 +4583,7 @@ int ARCore::subThread()
 		TwoImpulseOpt opt;
 		TwoImpulseResuls res;
 
-		if (GC->MissionPlanningActive)
+		if (GD->MissionPlanningActive)
 		{
 			opt.mode = 4;
 			opt.PlanNumber = GC->rtcc->med_m72.Plan;
@@ -4613,7 +4670,7 @@ int ARCore::subThread()
 	break;
 	case 39: //Transfer SPQ, DKI or descent planning to MPT
 	{
-		if (GC->MissionPlanningActive)
+		if (GD->MissionPlanningActive)
 		{
 			std::vector<std::string> str;
 			GC->rtcc->PMMMED("70", str);
@@ -4720,7 +4777,7 @@ int ARCore::subThread()
 		TwoImpulseOpt opt;
 		TwoImpulseResuls res;
 
-		if (GC->MissionPlanningActive)
+		if (GD->MissionPlanningActive)
 		{
 			double GMT;
 			if (GC->rtcc->med_k32.ChaserVectorTime > 0)
@@ -4753,7 +4810,7 @@ int ARCore::subThread()
 		}
 		else
 		{
-			if (GC->rtcc->pCSM == NULL || GC->rtcc->pLM == NULL)
+			if (GD->pCSM == NULL || GD->pLM == NULL)
 			{
 				Result = DONE;
 				break;
@@ -4762,13 +4819,13 @@ int ARCore::subThread()
 			VESSEL *chaser, *tgt;
 			if (GC->rtcc->med_k32.Vehicle == 1)
 			{
-				chaser = GC->rtcc->pCSM;
-				tgt = GC->rtcc->pLM;
+				chaser = GD->pCSM;
+				tgt = GD->pLM;
 			}
 			else
 			{
-				chaser = GC->rtcc->pLM;
-				tgt = GC->rtcc->pCSM;
+				chaser = GD->pLM;
+				tgt = GD->pCSM;
 			}
 
 			opt.sv_C = GC->rtcc->StateVectorCalcDataBlock(chaser);
@@ -4810,7 +4867,7 @@ int ARCore::subThread()
 	break;
 	case 43: //Direct Input of Lunar Descent Maneuver
 	{
-		if (GC->MissionPlanningActive)
+		if (GD->MissionPlanningActive)
 		{
 			//Temporary
 			GC->rtcc->med_m86.Time = GC->rtcc->CZTDTGTU.GETTD;
@@ -4824,7 +4881,7 @@ int ARCore::subThread()
 	break;
 	case 44: //Transfer ascent maneuver to MPT from lunar targeting
 	{
-		if (GC->MissionPlanningActive)
+		if (GD->MissionPlanningActive)
 		{
 			std::vector<std::string> str;
 			GC->rtcc->PMMMED("85", str);
@@ -4835,7 +4892,7 @@ int ARCore::subThread()
 	break;
 	case 45: //Transfer GPM to the MPT
 	{
-		if (GC->MissionPlanningActive)
+		if (GD->MissionPlanningActive)
 		{
 			std::vector<std::string> str;
 			GC->rtcc->PMMMED("65", str);
@@ -4897,7 +4954,7 @@ int ARCore::subThread()
 	break;
 	case 46: //TLI Direct Input
 	{
-		if (!GC->MissionPlanningActive)
+		if (!GD->MissionPlanningActive)
 		{
 			Result = DONE;
 			break;
@@ -4913,7 +4970,7 @@ int ARCore::subThread()
 	break;
 	case 47: //Abort Scan Table
 	{
-		if (GC->MissionPlanningActive)
+		if (GD->MissionPlanningActive)
 		{
 			if (RTEASTType == 75)
 			{
@@ -4930,7 +4987,7 @@ int ARCore::subThread()
 		}
 		else
 		{
-			VESSEL *v = GC->rtcc->pCSM;
+			VESSEL *v = GD->pCSM;
 
 			if (v == NULL)
 			{
@@ -5004,7 +5061,7 @@ int ARCore::subThread()
 	break;
 	case 48: //LOI and MCC Transfer
 	{
-		if (GC->MissionPlanningActive)
+		if (GD->MissionPlanningActive)
 		{
 			//With the MPT, just call the MED function
 			std::vector<std::string> data;
@@ -5194,11 +5251,11 @@ int ARCore::subThread()
 			VESSEL *v;
 			if (GC->AGOP_AttIsCSM)
 			{
-				v = GC->rtcc->pCSM;
+				v = GD->pCSM;
 			}
 			else
 			{
-				v = GC->rtcc->pLM;
+				v = GD->pLM;
 			}
 
 			if (v == NULL)
@@ -5433,7 +5490,7 @@ int ARCore::subThread()
 			Result = DONE;
 			break;
 		}
-		if (GC->MissionPlanningActive)
+		if (GD->MissionPlanningActive)
 		{
 			VehicleDataBlock block;
 			std::string StaID;
@@ -5642,7 +5699,7 @@ int ARCore::subThread()
 	{
 		GC->rtcc->PZMARM.t_Calc_ARM = GC->rtcc->RTCCPresentTimeGMT();
 
-		if (GC->rtcc->pCSM == NULL || GC->rtcc->pLM == NULL)
+		if (GD->pCSM == NULL || GD->pLM == NULL)
 		{
 			Result = DONE;
 			break;
@@ -5650,8 +5707,8 @@ int ARCore::subThread()
 
 		EphemerisData sv_CSM, sv_LM;
 
-		sv_CSM = GC->rtcc->StateVectorCalcEphem(GC->rtcc->pCSM);
-		sv_LM = GC->rtcc->StateVectorCalcEphem(GC->rtcc->pLM);
+		sv_CSM = GC->rtcc->StateVectorCalcEphem(GD->pCSM);
+		sv_LM = GC->rtcc->StateVectorCalcEphem(GD->pLM);
 
 		GC->rtcc->PMDARM(sv_CSM, sv_LM);
 		Result = DONE;
@@ -5661,7 +5718,7 @@ int ARCore::subThread()
 	{
 		GC->rtcc->PZMARM.t_Calc_ShortARM = GC->rtcc->RTCCPresentTimeGMT();
 
-		if (GC->rtcc->pCSM == NULL || GC->rtcc->pLM == NULL)
+		if (GD->pCSM == NULL || GD->pLM == NULL)
 		{
 			Result = DONE;
 			break;
@@ -5669,8 +5726,8 @@ int ARCore::subThread()
 
 		EphemerisData sv_CSM, sv_LM;
 
-		sv_CSM = GC->rtcc->StateVectorCalcEphem(GC->rtcc->pCSM);
-		sv_LM = GC->rtcc->StateVectorCalcEphem(GC->rtcc->pLM);
+		sv_CSM = GC->rtcc->StateVectorCalcEphem(GD->pCSM);
+		sv_LM = GC->rtcc->StateVectorCalcEphem(GD->pLM);
 
 		GC->rtcc->PMDSARM(sv_CSM, sv_LM);
 		Result = DONE;
@@ -6046,12 +6103,12 @@ int ARCore::GetVesselParameters(bool IsCSM, int docked, int Thruster, int &Confi
 
 	if (IsCSM)
 	{
-		v = GC->rtcc->pCSM;
+		v = GD->pCSM;
 		vestype = 0;
 	}
 	else
 	{
-		v = GC->rtcc->pLM;
+		v = GD->pLM;
 		vestype = 1;
 	}
 
@@ -6100,11 +6157,11 @@ int ARCore::menuCalculateAttitudeComparison(bool IsCSM, bool IsAGC)
 
 	if (IsCSM)
 	{
-		v = GC->rtcc->pCSM;
+		v = GD->pCSM;
 	}
 	else
 	{
-		v = GC->rtcc->pLM;
+		v = GD->pLM;
 	}
 
 	if (v == NULL) return 1;
@@ -6210,7 +6267,7 @@ int ARCore::GetVehicleDataBlock(int L, double VectorTimeGET, std::string VectorI
 	//This function works like the internal logic of K-type MEDs to get AEG data blocks
 	//It works for both for MPT and non-MPT mode. Vector from VPS is supported in both modes
 	//Return value other than 0 is an error
-	if (GC->MissionPlanningActive)
+	if (GD->MissionPlanningActive)
 	{
 		double GMT;
 
@@ -6233,7 +6290,7 @@ int ARCore::GetVehicleDataBlock(int L, double VectorTimeGET, std::string VectorI
 	else
 	{
 		//First get whole vehicle data block
-		VESSEL *v = (L == RTCC_MPT_CSM ? GC->rtcc->pCSM : GC->rtcc->pLM);
+		VESSEL *v = (L == RTCC_MPT_CSM ? GD->pCSM : GD->pLM);
 		if (v == NULL) return 1;
 		sv = GC->rtcc->StateVectorCalcDataBlock(v);
 
@@ -6280,7 +6337,7 @@ int ARCore::VectorFetch(int L, double VectorTimeGET, std::string VectorID, Ephem
 	else
 	{
 		//No. Now the logic differs between MPT and non-MPT mode
-		if (GC->MissionPlanningActive)
+		if (GD->MissionPlanningActive)
 		{
 			double gmt;
 			if (VectorTimeGET != 0.0)
@@ -6312,11 +6369,11 @@ int ARCore::VectorFetch(int L, double VectorTimeGET, std::string VectorID, Ephem
 
 			if (L == RTCC_MPT_CSM)
 			{
-				v = GC->rtcc->pCSM;
+				v = GD->pCSM;
 			}
 			else
 			{
-				v = GC->rtcc->pLM;
+				v = GD->pLM;
 			}
 
 			if (v == NULL)

--- a/Orbitersdk/samples/ProjectApollo/src_rtccmfd/ARCore.h
+++ b/Orbitersdk/samples/ProjectApollo/src_rtccmfd/ARCore.h
@@ -42,10 +42,40 @@ struct MEDInputPage
 	int display = -1;
 };
 
+// Global data storage. Always exists when the RTCC MFD module is activated.
+class AR_GlobalData
+{
+public:
+	AR_GlobalData();
+
+	void SaveState(FILEHANDLE scn);
+	void LoadState(FILEHANDLE scn);
+
+	// GLOBAL VARIABLES
+	
+	// true = MPT is used, false = MPT is not used
+	bool MissionPlanningActive;
+
+	//Vessel pointers to be used exclusively by the RTCC MFD
+	VESSEL* pCSM, * pLM;
+	char CSMName[64];
+	char LEMName[64];
+
+	// Time of lunar liftoff
+	double t_LunarLiftoff;
+
+	// Time from TIG of sextant star check
+	double sxtstardtime;
+
+	// Generally used TPI time
+	double t_TPI;
+};
+
+// Global RTCC MFD class. Gets created when RTCC MFD is first opened in an Orbiter session.
 class AR_GCore
 {
 public:
-	AR_GCore(VESSEL* v);
+	AR_GCore(AR_GlobalData* GD, VESSEL* v);
 	~AR_GCore();
 
 	void SetMissionSpecificParameters(int mission);
@@ -55,12 +85,11 @@ public:
 	bool AGOP_CSM_REFSMMAT_Required();
 	bool AGOP_LM_REFSMMAT_Required();
 
-	bool MissionPlanningActive;
-
 	int mptInitError;
 
 	double REFSMMAT_PTC_MJD;
 
+	AR_GlobalData* GD;
 	RTCC* rtcc;
 
 	//MANEUVER PAD PAGE
@@ -116,9 +145,6 @@ public:
 	int DEDA224, DEDA225, DEDA226, DEDA227, DEDA305, DEDA662, DEDA673, PDAP_ErrorCode;
 	double PDAP_J1, PDAP_K1, PDAP_J2, PDAP_K2, PDAP_Theta_LIM, PDAP_R_amin, PDAP_V_hmin, PDAP_A_min, PDAP_A_max;
 
-	//GENERAL PARAMETERS
-	double t_TPI;				// Generally used TPI time
-
 	//MANUAL ENTRY DEVICE
 	std::vector<MEDInputPage> MEDInputData;
 
@@ -131,7 +157,7 @@ protected:
 
 class ARCore {
 public:
-	ARCore(VESSEL* v, AR_GCore* gcin);
+	ARCore(VESSEL* v, AR_GCore* gcin, AR_GlobalData* gdin);
 	~ARCore();
 	void LunarLaunchTargetingCalc();
 	void LDPPalc();
@@ -306,8 +332,6 @@ public:
 
 	//ENTRY PAGE
 	double entryrange;
-	int landingzone; //0 = Mid Pacific, 1 = East Pacific, 2 = Atlantic Ocean, 3 = Indian Ocean, 4 = West Pacific
-	int entryprecision; //0 = conic, 1 = precision, 2 = PeA=-30 solution
 	double RTEReentryTime; //Desired landing time
 	int RTECalcMode; // 0 = ATP Tradeoff, 1 = ATP Search, 2 = ATP Discrete, 3 = UA Search, 4 = UA Discrete
 	int RTETradeoffMode; //0 = Near-Earth (F70), 1 = Remote-Earth (F71)
@@ -324,7 +348,6 @@ public:
 	//MANEUVER PAD PAGE
 	bool HeadsUp;
 	int manpadopt; //0 = CSM Maneuver PAD, 1 = LM Maneuver PAD, 2 = TPI PAD, 3 = TLI PAD, 4 = PDI PAD
-	double sxtstardtime;
 	double manpad_ullage_dt;
 	bool manpad_ullage_opt; //true = 4 jets, false = 2 jets
 	int manpad_pref_GDC_stars; // Preferred star set for the GDC backup alignment. 0 = Deneb, Vega, 1 = Navi, Polaris, 2 = Acrux, Atria, 3 = Sirius, Rigel
@@ -354,7 +377,6 @@ public:
 
 	//LM Ascent PAD
 	AP11LMASCPAD lmascentpad;
-	double t_LunarLiftoff;
 	int AscentPADVersion; //0 = Apollo 11-13, 1 = Apollo 14-17
 	double LAP_Phase, LAP_CR;
 
@@ -412,6 +434,7 @@ public:
 
 private:
 
+	AR_GlobalData* GD;
 	AR_GCore* GC;
 };
 

--- a/Orbitersdk/samples/ProjectApollo/src_rtccmfd/ARoapiModule.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_rtccmfd/ARoapiModule.cpp
@@ -38,6 +38,7 @@ See http://nassp.sourceforge.net/license/ for more details.
 extern ARoapiModule *g_coreMod;
 extern ARCore *GCoreData[32];
 extern VESSEL *GCoreVessel[32];
+extern AR_GlobalData g_GlobalData;
 extern AR_GCore *g_SC;
 extern int nGutsUsed;
 extern int g_MFDmode;
@@ -122,4 +123,14 @@ void ARoapiModule::clbkDeleteVessel(OBJHANDLE hVessel) {                     // 
 			break;
 		}
 	}
+}
+
+DLLCLBK void opcSaveState(FILEHANDLE scn)
+{
+	g_GlobalData.SaveState(scn);
+}
+
+DLLCLBK void opcLoadState(FILEHANDLE scn)
+{
+	g_GlobalData.LoadState(scn);
 }

--- a/Orbitersdk/samples/ProjectApollo/src_rtccmfd/ApolloRTCCMFD.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_rtccmfd/ApolloRTCCMFD.cpp
@@ -6877,6 +6877,12 @@ void ApolloRTCCMFD::menuVECPOINTCalc()
 	G->VecPointCalc(IsCSM);
 }
 
+void ApolloRTCCMFD::RecallStatus(void)
+{
+	//MFD data got reloaded in LoadState from the constructor, but resetting the MFD buttons crashes there. Do it here instead
+	SelectPage(screen);
+}
+
 void ApolloRTCCMFD::GetREFSMMATfromAGC()
 {
 	agc_t *vagc = G->GetAGCPointer(IsCSM);

--- a/Orbitersdk/samples/ProjectApollo/src_rtccmfd/ApolloRTCCMFD.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_rtccmfd/ApolloRTCCMFD.cpp
@@ -31,6 +31,7 @@ ARoapiModule *g_coreMod;
 int g_MFDmode; // identifier for new MFD mode
 ARCore *GCoreData[32];
 VESSEL *GCoreVessel[32];
+AR_GlobalData g_GlobalData;
 AR_GCore *g_SC = NULL;      // points to the static core, root of all persistence
 int nGutsUsed;
 bool initialised = false;
@@ -51,8 +52,9 @@ ApolloRTCCMFD::ApolloRTCCMFD (DWORD w, DWORD h, VESSEL *vessel, UINT im)
 	subsubscreenmax = 0;
 
 	if (!g_SC) {
-		g_SC = new AR_GCore(vessel);                     // First time only in this Orbiter session. Init the static core.
+		g_SC = new AR_GCore(&g_GlobalData, vessel);  // First time only in this Orbiter session. Init the static core.
 	}
+	GD = &g_GlobalData;
 	GC = g_SC;                                  // Make the ApolloRTCCMFD instance Global Core point to the static core. 
 
 	font_mocr_plot = oapiCreateFont(w / 31, true, "Arial", FONT_NORMAL, 0);
@@ -120,7 +122,7 @@ ApolloRTCCMFD::ApolloRTCCMFD (DWORD w, DWORD h, VESSEL *vessel, UINT im)
 	}
 	if (!found)
 	{
-		GCoreData[nGutsUsed] = new ARCore(vessel, GC);
+		GCoreData[nGutsUsed] = new ARCore(vessel, GC, &g_GlobalData);
 		G = GCoreData[nGutsUsed];
 		GCoreVessel[nGutsUsed] = vessel;
 		nGutsUsed++;
@@ -245,107 +247,6 @@ bool ApolloRTCCMFD::ConsumeButton(int bt, int event)
 bool ApolloRTCCMFD::ConsumeKeyBuffered(DWORD key)
 {
 	return coreButtons.ConsumeKeyBuffered(this, key);
-}
-
-void ApolloRTCCMFD::WriteStatus(FILEHANDLE scn) const
-{
-	//oapiWriteScenario_int(scn, "SCREEN", G->screen);
-	papiWriteScenario_bool(scn, "VESSELISDOCKED", G->vesselisdocked);
-	papiWriteScenario_double(scn, "SXTSTARDTIME", G->sxtstardtime);
-	oapiWriteScenario_int(scn, "REFSMMATopt", G->REFSMMATopt);
-	papiWriteScenario_double(scn, "REFSMMAT_LVLH_Time", G->REFSMMAT_LVLH_Time);
-	papiWriteScenario_bool(scn, "REFSMMATHeadsUp", G->REFSMMATHeadsUp);
-	papiWriteScenario_double(scn, "CDHTIME", GC->rtcc->med_k01.CDH_Time);
-	oapiWriteScenario_int(scn, "CDHTIMEMODE", G->CDHtimemode);
-
-	papiWriteScenario_double(scn, "P30TIG", G->P30TIG);
-	papiWriteScenario_vec(scn, "DV_LVLH", G->dV_LVLH);
-	papiWriteScenario_double(scn, "ENTRYRANGE", G->entryrange);
-	oapiWriteScenario_int(scn, "LANDINGZONE", G->landingzone);
-	oapiWriteScenario_int(scn, "ENTRYPRECISION", G->entryprecision);
-
-	oapiWriteScenario_int(scn, "MAPPAGE", G->mappage);
-	papiWriteScenario_double(scn, "GMPApogeeHeight", G->GMPApogeeHeight);
-	papiWriteScenario_double(scn, "GMPPerigeeHeight", G->GMPPerigeeHeight);
-	papiWriteScenario_double(scn, "GMPWedgeAngle", G->GMPWedgeAngle);
-	papiWriteScenario_double(scn, "GMPManeuverHeight", G->GMPManeuverHeight);
-	papiWriteScenario_double(scn, "GMPManeuverLongitude", G->GMPManeuverLongitude);
-	papiWriteScenario_double(scn, "GMPHeightChange", G->GMPHeightChange);
-	papiWriteScenario_double(scn, "GMPNodeShiftAngle", G->GMPNodeShiftAngle);
-	papiWriteScenario_double(scn, "GMPDeltaVInput", G->GMPDeltaVInput);
-	papiWriteScenario_double(scn, "GMPPitch", G->GMPPitch);
-	papiWriteScenario_double(scn, "GMPYaw", G->GMPYaw);
-	papiWriteScenario_double(scn, "GMPApseLineRotAngle", G->GMPApseLineRotAngle);
-	oapiWriteScenario_int(scn, "GMPRevs", G->GMPRevs);
-	oapiWriteScenario_int(scn, "GMPManeuverPoint", G->GMPManeuverPoint);
-	oapiWriteScenario_int(scn, "GMPManeuverType", G->GMPManeuverType);
-	oapiWriteScenario_int(scn, "GMPManeuverCode", G->GMPManeuverCode);
-	papiWriteScenario_double(scn, "SPSGET", GC->rtcc->med_k20.ThresholdTime);
-
-	papiWriteScenario_double(scn, "LDPPGETTH1", GC->rtcc->med_k16.GETTH1);
-	papiWriteScenario_double(scn, "LDPPGETTH2", GC->rtcc->med_k16.GETTH2);
-	papiWriteScenario_double(scn, "LDPPGETTH3", GC->rtcc->med_k16.GETTH3);
-	papiWriteScenario_double(scn, "LDPPGETTH4", GC->rtcc->med_k16.GETTH4);
-
-	papiWriteScenario_double(scn, "t_Liftoff_guess", G->t_LunarLiftoff);
-	papiWriteScenario_double(scn, "t_TPIguess", G->t_TPIguess);
-
-	papiWriteScenario_bool(scn, "MISSIONPLANNINGACTIVE", GC->MissionPlanningActive);
-}
-
-void ApolloRTCCMFD::ReadStatus(FILEHANDLE scn)
-{
-	char *line;
-
-	while (oapiReadScenario_nextline(scn, line)) {
-		if (!strnicmp(line, "END_MFD", 7))
-			break;
-
-		//papiReadScenario_int(line, "SCREEN", G->screen);
-		papiReadScenario_bool(line, "VESSELISDOCKED", G->vesselisdocked);
-		papiReadScenario_double(line, "SXTSTARDTIME", G->sxtstardtime);
-		papiReadScenario_int(line, "REFSMMATopt", G->REFSMMATopt);
-		papiReadScenario_double(line, "REFSMMAT_LVLH_Time", G->REFSMMAT_LVLH_Time);
-		papiReadScenario_bool(line, "REFSMMATHeadsUp", G->REFSMMATHeadsUp);
-		papiReadScenario_double(line, "CDHTIME", GC->rtcc->med_k01.CDH_Time);
-		papiReadScenario_int(line, "CDHTIMEMODE", G->CDHtimemode);
-
-		papiReadScenario_double(line, "P30TIG", G->P30TIG);
-		papiReadScenario_vec(line, "DV_LVLH", G->dV_LVLH);
-		papiReadScenario_double(line, "ENTRYRANGE", G->entryrange);
-		papiReadScenario_int(line, "LANDINGZONE", G->landingzone);
-		papiReadScenario_int(line, "ENTRYPRECISION", G->entryprecision);
-
-		papiReadScenario_int(line, "MAPPAGE", G->mappage);
-		papiReadScenario_double(line, "GMPApogeeHeight", G->GMPApogeeHeight);
-		papiReadScenario_double(line, "GMPPerigeeHeight", G->GMPPerigeeHeight);
-		papiReadScenario_double(line, "GMPWedgeAngle", G->GMPWedgeAngle);
-		papiReadScenario_double(line, "GMPManeuverHeight", G->GMPManeuverHeight);
-		papiReadScenario_double(line, "GMPManeuverLongitude", G->GMPManeuverLongitude);
-		papiReadScenario_double(line, "GMPHeightChange", G->GMPHeightChange);
-		papiReadScenario_double(line, "GMPNodeShiftAngle", G->GMPNodeShiftAngle);
-		papiReadScenario_double(line, "GMPDeltaVInput", G->GMPDeltaVInput);
-		papiReadScenario_double(line, "GMPPitch", G->GMPPitch);
-		papiReadScenario_double(line, "GMPYaw", G->GMPYaw);
-		papiReadScenario_double(line, "GMPApseLineRotAngle", G->GMPApseLineRotAngle);
-		papiReadScenario_int(line, "GMPRevs", G->GMPRevs);
-		papiReadScenario_int(line, "GMPManeuverPoint", G->GMPManeuverPoint);
-		papiReadScenario_int(line, "GMPManeuverType", G->GMPManeuverType);
-		papiReadScenario_int(line, "GMPManeuverCode", G->GMPManeuverCode);
-		papiReadScenario_double(line, "SPSGET", GC->rtcc->med_k20.ThresholdTime);
-
-		papiReadScenario_double(line, "LDPPGETTH1", GC->rtcc->med_k16.GETTH1);
-		papiReadScenario_double(line, "LDPPGETTH2", GC->rtcc->med_k16.GETTH2);
-		papiReadScenario_double(line, "LDPPGETTH3", GC->rtcc->med_k16.GETTH3);
-		papiReadScenario_double(line, "LDPPGETTH4", GC->rtcc->med_k16.GETTH4);
-
-		papiReadScenario_double(line, "t_Liftoff_guess", G->t_LunarLiftoff);
-		papiReadScenario_double(line, "t_TPIguess", G->t_TPIguess);
-
-		papiReadScenario_bool(line, "MISSIONPLANNINGACTIVE", GC->MissionPlanningActive);
-
-		//G->coreButtons.SelectPage(this, G->screen);
-	}
 }
 
 void ApolloRTCCMFD::Text_Double(oapi::Sketchpad *skp, int x, int y, char *format, double val)
@@ -511,7 +412,7 @@ void ApolloRTCCMFD::menuEntryUpdateUpload()
 
 void ApolloRTCCMFD::menuP30UplinkCalc()
 {
-	if (GC->MissionPlanningActive)
+	if (GD->MissionPlanningActive)
 	{
 		menuGeneralMEDRequest("Get TIG and DV from MPT. Format: C10, Vehicle Type (CMC or LGC), Maneuver Number (1-15), MPT Indicator (CSM or LEM);");
 	}
@@ -1599,7 +1500,7 @@ void ApolloRTCCMFD::CyclePerigeeAdjustVehicle()
 
 void ApolloRTCCMFD::menuPerigeeAdjustVectorTime()
 {
-	if (GC->MissionPlanningActive)
+	if (GD->MissionPlanningActive)
 	{
 		GenericGETInput(&GC->rtcc->med_k28.VectorTime, "Enter desired vector GET (Format: HH:MM:SS)");
 	}
@@ -1897,7 +1798,7 @@ void ApolloRTCCMFD::menuSetLWPInput()
 			}
 			break;
 		case 1:
-			if (GC->MissionPlanningActive)
+			if (GD->MissionPlanningActive)
 			{
 				GenericGETInput(&GC->rtcc->PZSLVCON.TargetVectorTime, "Enter desired target vector time in GET (Format: HH:MM:SS). Enter negative value to use present time.");
 			}
@@ -3133,7 +3034,7 @@ void ApolloRTCCMFD::set_ASTSiteOrType(char *site)
 
 void ApolloRTCCMFD::menuASTVectorTime()
 {
-	if (GC->MissionPlanningActive)
+	if (GD->MissionPlanningActive)
 	{
 		GenericGETInput(&GC->rtcc->med_f75_f77.T_V, "Choose the vector GET (Format: hhh:mm:ss)");
 	}
@@ -3233,7 +3134,7 @@ bool DeleteASTRowInput(void *id, char *str, void *data)
 
 void ApolloRTCCMFD::menuRTEDManualVectorTime()
 {
-	if (GC->MissionPlanningActive)
+	if (GD->MissionPlanningActive)
 	{
 		bool RTEDManualVectorTimeInput(void *id, char *str, void *data);
 		oapiOpenInputBox("Choose the vector GET (Format: hhh:mm:ss)", RTEDManualVectorTimeInput, 0, 25, (void*)this);
@@ -3719,7 +3620,7 @@ void ApolloRTCCMFD::menuSetGMPInput()
 		}
 		break;
 	case 2:
-		if (GC->MissionPlanningActive)
+		if (GD->MissionPlanningActive)
 		{
 			GenericGETInput(&GC->rtcc->med_k20.VectorTime, "Choose the vector GET (Format: hhh:mm:ss), 0 or smaller for present time");
 		}
@@ -3862,7 +3763,7 @@ void ApolloRTCCMFD::menuSetTIMultipleSolutionInput()
 			GC->rtcc->med_k30.IVFlag = 0;
 		break;
 	case 2:
-		if (GC->MissionPlanningActive)
+		if (GD->MissionPlanningActive)
 		{
 			GenericGETInput(&GC->rtcc->med_k30.ChaserVectorTime, "Choose the chaser vector GET (Format: hhh:mm:ss), 0 or smaller for present time");
 		}
@@ -3873,7 +3774,7 @@ void ApolloRTCCMFD::menuSetTIMultipleSolutionInput()
 		}
 		break;
 	case 3:
-		if (GC->MissionPlanningActive)
+		if (GD->MissionPlanningActive)
 		{
 			GenericGETInput(&GC->rtcc->med_k30.TargetVectorTime, "Choose the target vector GET (Format: hhh:mm:ss), 0 or smaller for present time");
 		}
@@ -4218,7 +4119,7 @@ void ApolloRTCCMFD::menuCycleRTEDColumn()
 
 void ApolloRTCCMFD::menusextantstartime()
 {
-	GenericDoubleInput(&G->sxtstardtime, "Minutes before Maneuver for sextant/boresight star check:", -60.0);
+	GenericDoubleInput(&GD->sxtstardtime, "Minutes before Maneuver for sextant/boresight star check:", -60.0);
 }
 
 void ApolloRTCCMFD::menuCyclePreferredGDCStarSet()
@@ -4237,7 +4138,7 @@ void ApolloRTCCMFD::REFSMMATTimeDialogue()
 {
 	if (G->REFSMMATopt == 0)
 	{
-		if (GC->MissionPlanningActive)
+		if (GD->MissionPlanningActive)
 		{
 			GenericIntInput(&G->REFSMMAT_ManNum, "Enter maneuver number (1-15):", NULL, 1, 15);
 		}
@@ -4301,7 +4202,7 @@ bool ApolloRTCCMFD::set_ChooseTIThruster(std::string th)
 
 void ApolloRTCCMFD::menuSetM70Inputs()
 {
-	int num = (GC->MissionPlanningActive ? subscreen : 0);
+	int num = (GD->MissionPlanningActive ? subscreen : 0);
 
 	switch (marker)
 	{
@@ -4312,7 +4213,7 @@ void ApolloRTCCMFD::menuSetM70Inputs()
 		GenericGETInput(&GC->rtcc->med_m70.DeleteGET, "Delete all maneuvers in both MPTs after GET (Format: hhh:mm:ss, or negative number for no delete)");
 		break;
 	case 2:
-		if (GC->MissionPlanningActive)
+		if (GD->MissionPlanningActive)
 		{
 			if (subscreen < 6) subscreen++;
 			else subscreen = 0;
@@ -4347,7 +4248,7 @@ void ApolloRTCCMFD::menuSetM70Inputs()
 		GC->rtcc->med_m70.ManData[num].TimeFlag = !GC->rtcc->med_m70.ManData[num].TimeFlag;
 		break;
 	case 10:
-		if (GC->MissionPlanningActive)
+		if (GD->MissionPlanningActive)
 		{
 			for (int i = 0; i < 7; i++)
 			{
@@ -4363,7 +4264,7 @@ void ApolloRTCCMFD::menuSetM70Inputs()
 
 void ApolloRTCCMFD::menuSetM72Inputs()
 {
-	int num = (GC->MissionPlanningActive ? subscreen : 0);
+	int num = (GD->MissionPlanningActive ? subscreen : 0);
 
 	switch (marker)
 	{
@@ -4409,7 +4310,7 @@ void ApolloRTCCMFD::menuSetM72Inputs()
 		GC->rtcc->med_m72.ManData[num].TimeFlag = !GC->rtcc->med_m72.ManData[num].TimeFlag;
 		break;
 	case 11:
-		if (GC->MissionPlanningActive)
+		if (GD->MissionPlanningActive)
 		{
 			for (int i = 0; i < 2; i++)
 			{
@@ -4937,9 +4838,9 @@ void ApolloRTCCMFD::menuMPTUpdate()
 
 void ApolloRTCCMFD::menuMPTTrajectoryUpdateCSM()
 {
-	if (GC->rtcc->pCSM)
+	if (GD->pCSM)
 	{
-		sprintf(Buffer, "%s", GC->rtcc->pCSM->GetName());
+		sprintf(Buffer, "%s", GD->pCSM->GetName());
 	}
 	else
 	{
@@ -4961,9 +4862,9 @@ bool DifferentialCorrectionSolutionCSMInput(void* id, char *str, void *data)
 
 void ApolloRTCCMFD::menuMPTTrajectoryUpdateLEM()
 {
-	if (GC->rtcc->pLM)
+	if (GD->pLM)
 	{
-		sprintf(Buffer, "%s", GC->rtcc->pLM->GetName());
+		sprintf(Buffer, "%s", GD->pLM->GetName());
 	}
 	else
 	{
@@ -5704,7 +5605,7 @@ void ApolloRTCCMFD::menuSetCorrectiveCombinationInput()
 		GC->rtcc->med_k32.RequestIndicator = 1 - GC->rtcc->med_k32.RequestIndicator;
 		break;
 	case 2:
-		if (GC->MissionPlanningActive)
+		if (GD->MissionPlanningActive)
 		{
 			GenericGETInput(&GC->rtcc->med_k32.ChaserVectorTime, "Choose the chaser vector time (Format: hhh:mm:ss), 0 or smaller for present time");
 		}
@@ -5715,7 +5616,7 @@ void ApolloRTCCMFD::menuSetCorrectiveCombinationInput()
 		}
 		break;
 	case 3:
-		if (GC->MissionPlanningActive)
+		if (GD->MissionPlanningActive)
 		{
 			GenericGETInput(&GC->rtcc->med_k32.TargetVectorTime, "Choose the target vector time (Format: hhh:mm:ss), 0 or smaller for present time");
 		}
@@ -5805,7 +5706,7 @@ void ApolloRTCCMFD::menuSLVLaunchTargeting()
 
 void ApolloRTCCMFD::menuSLVInsertionSVtoMPT()
 {
-	if (GC->MissionPlanningActive == false) return;
+	if (GD->MissionPlanningActive == false) return;
 	if (GC->rtcc->GZLTRA.GMT_T == 0.0) return;
 
 	StateVectorTableEntry sv0;
@@ -5854,12 +5755,12 @@ void ApolloRTCCMFD::set_Vessel()
 
 void ApolloRTCCMFD::set_CSMVessel()
 {
-	CycleThroughVessels(&GC->rtcc->pCSM);
+	CycleThroughVessels(&GD->pCSM);
 }
 
 void ApolloRTCCMFD::set_LMVessel()
 {
-	CycleThroughVessels(&GC->rtcc->pLM);
+	CycleThroughVessels(&GD->pLM);
 }
 
 void ApolloRTCCMFD::set_IUVessel()
@@ -5874,7 +5775,7 @@ void ApolloRTCCMFD::set_TargetVessel()
 
 void ApolloRTCCMFD::set_TargetVesselTable()
 {
-	if (GC->MissionPlanningActive)
+	if (GD->MissionPlanningActive)
 	{
 		G->Rendezvous_Target_Table = 4 - G->Rendezvous_Target_Table;
 	}
@@ -6212,7 +6113,7 @@ void ApolloRTCCMFD::LoadSplashdownTargetToRTEDManualInput()
 
 void ApolloRTCCMFD::menuTransferRTEToMPT()
 {
-	if (GC->MissionPlanningActive)
+	if (GD->MissionPlanningActive)
 	{
 		bool TransferRTEMPTInput(void *id, char *str, void *data);
 		oapiOpenInputBox("Format: M74,MPT (CSM or LEM), Replace Code (1-15 or missing), Maneuver Type (TTFM for deorbit, RTEP for RTE primary column, RTEM for manual column);", TransferRTEMPTInput, 0, 50, (void*)this);
@@ -6334,7 +6235,7 @@ void ApolloRTCCMFD::EntryRangeDialogue()
 
 void ApolloRTCCMFD::set_SVPageTarget()
 {
-	if (GC->MissionPlanningActive == false)
+	if (GD->MissionPlanningActive == false)
 	{
 		if (subscreen == 0 || subscreen == 2)
 		{
@@ -6363,14 +6264,14 @@ void ApolloRTCCMFD::menuSVCalc()
 	VESSEL *v;
 	if (subscreen == 0 || subscreen == 2)
 	{
-		v = GC->rtcc->pCSM;
+		v = GD->pCSM;
 	}
 	else
 	{
-		v = GC->rtcc->pLM;
+		v = GD->pLM;
 	}
 
-	if (GC->MissionPlanningActive || (v != NULL && !v->GroundContact()))
+	if (GD->MissionPlanningActive || (v != NULL && !v->GroundContact()))
 	{
 		int type = AGCSVUplinkType(subscreen);
 		G->StateVectorCalc(type);
@@ -6478,7 +6379,7 @@ void ApolloRTCCMFD::menuCalcManPAD()
 	{
 	case 0:
 	case 1:
-		if (GC->MissionPlanningActive)
+		if (GD->MissionPlanningActive)
 		{
 			bool ManPADMPTInput(void *id, char *str, void *data);
 			oapiOpenInputBox("Enter MPT (CSM or LEM) and maneuver number (1-15):", ManPADMPTInput, 0, 20, (void*)this);
@@ -6645,7 +6546,7 @@ void ApolloRTCCMFD::menuSetSPQInput()
 		GC->rtcc->med_k01.ChaserVehicle = 4 - GC->rtcc->med_k01.ChaserVehicle;
 		break;
 	case 1:
-		if (GC->MissionPlanningActive)
+		if (GD->MissionPlanningActive)
 		{
 			GenericGETInput(&GC->rtcc->med_k01.ChaserThresholdGET, "Choose the SPQ chaser threshold (Format: hhh:mm:ss)");
 		}
@@ -6662,7 +6563,7 @@ void ApolloRTCCMFD::menuSetSPQInput()
 		}
 		break;
 	case 2:
-		if (GC->MissionPlanningActive)
+		if (GD->MissionPlanningActive)
 		{
 			GenericGETInput(&GC->rtcc->med_k01.TargetThresholdGET, "Choose the SPQ target threshold (Format: hhh:mm:ss)");
 		}
@@ -6895,7 +6796,7 @@ bool ApolloRTCCMFD::set_LiftoffTime(bool IsCMC)
 	GC->rtcc->GMGMED(Buff);
 
 	//Also update IU, if possible
-	G->UpdateGRRTime(GC->rtcc->pCSM);
+	G->UpdateGRRTime(GD->pCSM);
 
 	return true;
 }
@@ -6976,12 +6877,6 @@ void ApolloRTCCMFD::menuVECPOINTCalc()
 	G->VecPointCalc(IsCSM);
 }
 
-void ApolloRTCCMFD::RecallStatus(void)
-{
-	//MFD data got reloaded in LoadState from the constructor, but resetting the MFD buttons crashes there. Do it here instead
-	SelectPage(screen);
-}
-
 void ApolloRTCCMFD::GetREFSMMATfromAGC()
 {
 	agc_t *vagc = G->GetAGCPointer(IsCSM);
@@ -7017,7 +6912,7 @@ void ApolloRTCCMFD::menuCycleLunarEntryPADSxtOption()
 
 void ApolloRTCCMFD::GetEntryTargetfromAGC()
 {
-	VESSEL *v = GC->rtcc->pCSM;
+	VESSEL *v = GD->pCSM;
 
 	if (v == NULL) return;
 
@@ -7076,7 +6971,7 @@ void ApolloRTCCMFD::menuTransferLOIMCCtoMPT()
 
 void ApolloRTCCMFD::menuTLCCVectorTime()
 {
-	if (GC->MissionPlanningActive)
+	if (GD->MissionPlanningActive)
 	{
 		GenericGETInput(&GC->rtcc->PZMCCPLN.VectorGET, "Choose the vector time for the maneuver (Format: hhh:mm:ss)");
 	}
@@ -7406,7 +7301,7 @@ void ApolloRTCCMFD::set_TLMCCLOPCRevs(int m, int n)
 
 void ApolloRTCCMFD::menuSetLOIVectorTime()
 {
-	if (GC->MissionPlanningActive)
+	if (GD->MissionPlanningActive)
 	{
 		GenericGETInput(&GC->rtcc->med_k18.VectorTime, "Choose the vector time for LOI computation:");
 	}
@@ -7616,7 +7511,7 @@ void ApolloRTCCMFD::menuSetLiftoffguess()
 
 void ApolloRTCCMFD::menuLLWPVectorTime()
 {
-	if (GC->MissionPlanningActive)
+	if (GD->MissionPlanningActive)
 	{
 		GenericGETInput(&GC->rtcc->med_k15.CSMVectorTime, "Choose the CSM vector time (Format: hhh:mm:ss)");
 	}
@@ -8038,7 +7933,7 @@ void ApolloRTCCMFD::menuLAPCalc()
 
 void ApolloRTCCMFD::menuSetLAPLiftoffTime()
 {
-	GenericGETInput(&G->t_LunarLiftoff, "Choose the liftoff time (Format: hhh:mm:ss)");
+	GenericGETInput(&GD->t_LunarLiftoff, "Choose the liftoff time (Format: hhh:mm:ss)");
 }
 
 void ApolloRTCCMFD::menuDKINSRLine()
@@ -8220,7 +8115,7 @@ void ApolloRTCCMFD::menuDKITerminalPhaseDefinitionValue()
 
 void ApolloRTCCMFD::menuChooseDKIChaser()
 {
-	if (GC->MissionPlanningActive)
+	if (GD->MissionPlanningActive)
 	{
 		GenericStringInput(&GC->rtcc->med_k10.ChaserVectorID, "Enter Vector ID from VPS if desired (otherwise leave blank):");
 	}
@@ -8233,7 +8128,7 @@ void ApolloRTCCMFD::menuChooseDKIChaser()
 
 void ApolloRTCCMFD::menuChooseDKITarget()
 {
-	if (GC->MissionPlanningActive)
+	if (GD->MissionPlanningActive)
 	{
 		GenericStringInput(&GC->rtcc->med_k10.TargetVectorID, "Enter Vector ID from VPS if desired (otherwise leave blank):");
 	}
@@ -8271,7 +8166,7 @@ void ApolloRTCCMFD::menuDAPPADCalc()
 
 void ApolloRTCCMFD::menuLaunchAzimuthCalc()
 {
-	VESSEL *v = GC->rtcc->pCSM;
+	VESSEL *v = GD->pCSM;
 
 	if (v == NULL) return;
 
@@ -8340,7 +8235,7 @@ void ApolloRTCCMFD::menuSetPDAPInputs()
 		}
 		break;
 	case 2:
-		if (GC->MissionPlanningActive)
+		if (GD->MissionPlanningActive)
 		{
 			GenericGETInput(&GC->PDAP_CSM_VectorTime, "Enter the CSM vector time:");
 		}
@@ -8350,7 +8245,7 @@ void ApolloRTCCMFD::menuSetPDAPInputs()
 		}
 		break;
 	case 3:
-		if (GC->MissionPlanningActive)
+		if (GD->MissionPlanningActive)
 		{
 			GenericGETInput(&GC->PDAP_LM_VectorTime, "Enter the LM vector time:");
 		}
@@ -8427,7 +8322,7 @@ bool ApolloRTCCMFD::set_PDAPInputs(int sel, char *str)
 	{
 		//Yes, auto detect
 		//Make sure we have a LM selected
-		VESSEL *v = GC->rtcc->pLM;
+		VESSEL *v = GD->pLM;
 		if (v == NULL || utils::IsVessel(v, utils::LEM) == false) return false;
 
 		LEM *l = (LEM*)v;
@@ -8475,7 +8370,7 @@ void ApolloRTCCMFD::menuPDAPCalc()
 
 void ApolloRTCCMFD::menuPDAPUplink()
 {
-	VESSEL *v = GC->rtcc->pLM;
+	VESSEL *v = GD->pLM;
 
 	if (v == NULL || utils::IsVessel(v, utils::LEM) == false) return;
 
@@ -8506,7 +8401,7 @@ void ApolloRTCCMFD::menuSetFIDOOrbitDigitalsGETBV()
 
 void ApolloRTCCMFD::menuSpaceDigitalsInit()
 {
-	if (GC->MissionPlanningActive)
+	if (GD->MissionPlanningActive)
 	{
 		bool SpaceDigitalsInitInput(void* id, char *str, void *data);
 		oapiOpenInputBox("Format: U00, CSM or LEM, E or M (optional);", SpaceDigitalsInitInput, 0, 20, (void*)this);
@@ -8534,7 +8429,7 @@ bool SpaceDigitalsInitInput(void *id, char *str, void *data)
 
 void ApolloRTCCMFD::menuGenerateSpaceDigitals()
 {
-	if (GC->MissionPlanningActive)
+	if (GD->MissionPlanningActive)
 	{
 		bool GenerateSpaceDigitalsInput(void* id, char *str, void *data);
 		oapiOpenInputBox("Generate Space Digitals, format: U01, column (1-3), option (GET or MNV), parameter (time or mnv number), Inclination (Col. 2), Long Ascending Node (Col. 2);", GenerateSpaceDigitalsInput, 0, 50, (void*)this);
@@ -8579,7 +8474,7 @@ bool GenerateSpaceDigitalsInput(void *id, char *str, void *data)
 
 void ApolloRTCCMFD::menuMPTCycleActive()
 {
-	GC->MissionPlanningActive = !GC->MissionPlanningActive;
+	GD->MissionPlanningActive = !GD->MissionPlanningActive;
 }
 
 void ApolloRTCCMFD::menuMPTDeleteManeuver()
@@ -8868,7 +8763,7 @@ void ApolloRTCCMFD::menuSetLDPPInput()
 		}
 		break;
 	case 1:
-		if (GC->MissionPlanningActive)
+		if (GD->MissionPlanningActive)
 		{
 			GenericGETInput(&GC->rtcc->med_k16.VectorTime, "Choose the vector time (Format: hhh:mm:ss)");
 		}
@@ -9772,7 +9667,7 @@ void ApolloRTCCMFD::menuAGCTimeUpdateComparison()
 	if (i == 0)
 	{
 		//CMC
-		VESSEL *v = GC->rtcc->pCSM;
+		VESSEL *v = GD->pCSM;
 
 		if (v == NULL || utils::IsVessel(v, utils::Saturn) == false)
 		{
@@ -9785,7 +9680,7 @@ void ApolloRTCCMFD::menuAGCTimeUpdateComparison()
 	else
 	{
 		//LGC
-		VESSEL *v = GC->rtcc->pLM;
+		VESSEL *v = GD->pLM;
 
 		if (v == NULL || utils::IsVessel(v, utils::LEM) == false)
 		{

--- a/Orbitersdk/samples/ProjectApollo/src_rtccmfd/ApolloRTCCMFD.h
+++ b/Orbitersdk/samples/ProjectApollo/src_rtccmfd/ApolloRTCCMFD.h
@@ -63,6 +63,7 @@ public:
 	bool Update (oapi::Sketchpad *skp);
 	bool ConsumeButton(int bt, int event);
 	bool ConsumeKeyBuffered(DWORD key);
+	void RecallStatus(void);
 
 	void Text_Double(oapi::Sketchpad *skp, int x, int y, char *format, double val);
 	void Text_Int(oapi::Sketchpad *skp, int x, int y, char *format, int val);

--- a/Orbitersdk/samples/ProjectApollo/src_rtccmfd/ApolloRTCCMFD.h
+++ b/Orbitersdk/samples/ProjectApollo/src_rtccmfd/ApolloRTCCMFD.h
@@ -63,9 +63,6 @@ public:
 	bool Update (oapi::Sketchpad *skp);
 	bool ConsumeButton(int bt, int event);
 	bool ConsumeKeyBuffered(DWORD key);
-	void WriteStatus(FILEHANDLE scn) const;
-	void ReadStatus(FILEHANDLE scn);
-	void RecallStatus(void);
 
 	void Text_Double(oapi::Sketchpad *skp, int x, int y, char *format, double val);
 	void Text_Int(oapi::Sketchpad *skp, int x, int y, char *format, int val);
@@ -904,6 +901,7 @@ private:
 
 	UINT ID;
 	ARCore* G;
+	AR_GlobalData* GD;
 	AR_GCore* GC;
 	ApolloRTCCMFDButtons coreButtons;
 

--- a/Orbitersdk/samples/ProjectApollo/src_rtccmfd/ApolloRTCCMFD_Display.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_rtccmfd/ApolloRTCCMFD_Display.cpp
@@ -63,7 +63,7 @@ bool ApolloRTCCMFD::Update(oapi::Sketchpad *skp)
 			else Text(skp, x + dx, y, "2: Second Fixed");
 			y++;
 			Text(skp, x, y, "CVT:");
-			if (GC->MissionPlanningActive)
+			if (GD->MissionPlanningActive)
 			{
 				if (GC->rtcc->med_k30.ChaserVectorTime > 0) Text_GET_HHHMMSSCS(skp, x + dx, y, GC->rtcc->med_k30.ChaserVectorTime);
 				else Text(skp, x + dx, y, "Present Time");
@@ -76,7 +76,7 @@ bool ApolloRTCCMFD::Update(oapi::Sketchpad *skp)
 				Text(skp, x + dx, y, Buffer); y++;
 			}
 			Text(skp, x, y, "TVT:");
-			if (GC->MissionPlanningActive)
+			if (GD->MissionPlanningActive)
 			{
 				if (GC->rtcc->med_k30.TargetVectorTime > 0) Text_GET_HHHMMSSCS(skp, x + dx, y, GC->rtcc->med_k30.TargetVectorTime);
 				else Text(skp, x + dx, y, "Present Time");
@@ -299,7 +299,7 @@ bool ApolloRTCCMFD::Update(oapi::Sketchpad *skp)
 			if (GC->rtcc->med_k01.ChaserVehicle == 1) Text(skp, x + dx, y, "CSM");
 			else Text(skp, x + dx, y, "LEM");
 			y++;
-			if (GC->MissionPlanningActive)
+			if (GD->MissionPlanningActive)
 			{
 				Text(skp, x, y, "CTH:");
 				if (GC->rtcc->med_k01.ChaserThresholdGET < 0)
@@ -325,7 +325,7 @@ bool ApolloRTCCMFD::Update(oapi::Sketchpad *skp)
 				Text(skp, x, y, Buffer);
 			}
 			y++;
-			if (GC->MissionPlanningActive)
+			if (GD->MissionPlanningActive)
 			{
 				Text(skp, x, y, "TTH:");
 				if (GC->rtcc->med_k01.TargetThresholdGET < 0)
@@ -447,7 +447,7 @@ bool ApolloRTCCMFD::Update(oapi::Sketchpad *skp)
 			skp->Text(CW * 6, CH * y, "LM", 2);
 		}
 		y++;
-		if (GC->MissionPlanningActive)
+		if (GD->MissionPlanningActive)
 		{
 			Text_String(skp, CW * 2, CH * y, "VTI");
 			GET_Display(Buffer, GC->rtcc->med_k20.VectorTime, false);
@@ -733,7 +733,7 @@ bool ApolloRTCCMFD::Update(oapi::Sketchpad *skp)
 			{
 				skp->Text(CW, 4 * H / 14, "P30 Retro", 9);
 			}
-			if (GC->MissionPlanningActive && G->REFSMMATopt == 0)
+			if (GD->MissionPlanningActive && G->REFSMMATopt == 0)
 			{
 				sprintf(Buffer, "Maneuver: %d", G->REFSMMAT_ManNum);
 				skp->Text(CW, 6 * H / 14, Buffer, strlen(Buffer));
@@ -777,7 +777,7 @@ bool ApolloRTCCMFD::Update(oapi::Sketchpad *skp)
 			{
 				skp->Text(CW, 4 * H / 14, "Landing Site", 12);
 
-				if (GC->MissionPlanningActive == false && IsCSM == false)
+				if (GD->MissionPlanningActive == false && IsCSM == false)
 				{
 					PrintCSMVessel(Buffer);
 					skp->Text(CW, 3 * H / 14, Buffer, strlen(Buffer));
@@ -1017,7 +1017,7 @@ bool ApolloRTCCMFD::Update(oapi::Sketchpad *skp)
 			skp->Text(CW, CH * 10, Buffer, strlen(Buffer));
 
 			skp->Text(CW, CH * 12, "Star Check:", 11);
-			sprintf(Buffer,"%.0f min", -G->sxtstardtime / 60.0);
+			sprintf(Buffer,"%.0f min", -GD->sxtstardtime / 60.0);
 			skp->Text(CW, CH * 13, Buffer, strlen(Buffer));
 
 			if (G->manpadopt == 0)
@@ -1026,7 +1026,7 @@ bool ApolloRTCCMFD::Update(oapi::Sketchpad *skp)
 				skp->Text(W / 2, CH / 2, "P30 Maneuver", 12);
 				skp->SetTextAlign(oapi::Sketchpad::LEFT);
 
-				if (GC->MissionPlanningActive == false)
+				if (GD->MissionPlanningActive == false)
 				{
 					if (G->vesselisdocked == false)
 					{
@@ -1052,7 +1052,7 @@ bool ApolloRTCCMFD::Update(oapi::Sketchpad *skp)
 				}
 				skp->Text(CW, CH * 15, Buffer, strlen(Buffer));
 
-				if (GC->MissionPlanningActive || G->vesselisdocked)
+				if (GD->MissionPlanningActive || G->vesselisdocked)
 				{
 					skp->Text(CW, CH * 17, "LM Weight:", 10);
 					sprintf(Buffer, "%.0lf", GC->manpad.LMWeight);
@@ -1165,7 +1165,7 @@ bool ApolloRTCCMFD::Update(oapi::Sketchpad *skp)
 				skp->Text(W / 2, CH / 2, "P30 LM Maneuver", 15);
 				skp->SetTextAlign(oapi::Sketchpad::LEFT);
 
-				if (GC->MissionPlanningActive == false)
+				if (GD->MissionPlanningActive == false)
 				{
 					if (G->vesselisdocked == false)
 					{
@@ -1184,7 +1184,7 @@ bool ApolloRTCCMFD::Update(oapi::Sketchpad *skp)
 				skp->Text(CW, CH * 17, "LM Weight:", 10);
 				sprintf(Buffer, "%.0lf", GC->lmmanpad.LMWeight);
 				skp->Text(CW, CH * 18, Buffer, strlen(Buffer));
-				if (GC->MissionPlanningActive || G->vesselisdocked)
+				if (GD->MissionPlanningActive || G->vesselisdocked)
 				{
 					skp->Text(CW, CH * 19, "CSM Weight:", 11);
 					sprintf(Buffer, "%.0lf", GC->lmmanpad.CSMWeight);
@@ -1554,12 +1554,6 @@ bool ApolloRTCCMFD::Update(oapi::Sketchpad *skp)
 				{
 					skp->Text(CW, 5 * H / 28, "Hor Check Attitude", 18);
 				}
-				if (G->entryrange != 0)
-				{
-					skp->Text(CW, 6 * H / 14, "Desired Range:", 14);
-					sprintf(Buffer, "%.1f NM", G->entryrange);
-					skp->Text(CW, 7 * H / 14, Buffer, strlen(Buffer));
-				}
 
 				sprintf(Buffer, "XXX%03.0f R 0.05G", GC->lunarentrypad.Att05[0].x);
 				skp->Text(CW * 23, CH * 5, Buffer, strlen(Buffer));
@@ -1693,7 +1687,7 @@ bool ApolloRTCCMFD::Update(oapi::Sketchpad *skp)
 			skp->Text(W / 2, CH / 2, "LOI Computation (K18)", 21);
 			skp->SetTextAlign(oapi::Sketchpad::LEFT);
 			skp->Text(CW, 2 * H / 14, "LOI Initialization", 18);
-			if (GC->MissionPlanningActive)
+			if (GD->MissionPlanningActive)
 			{
 				GET_Display(Buffer, GC->rtcc->med_k18.VectorTime);
 			}
@@ -1846,7 +1840,7 @@ bool ApolloRTCCMFD::Update(oapi::Sketchpad *skp)
 		else Text(skp, x + dx, y, "LEM");
 		y++;
 		Text(skp, x, y, "VTI:");
-		if (GC->MissionPlanningActive)
+		if (GD->MissionPlanningActive)
 		{
 			GET_Display2(Buffer, GC->rtcc->med_k16.VectorTime);
 		}
@@ -2085,7 +2079,7 @@ bool ApolloRTCCMFD::Update(oapi::Sketchpad *skp)
 			break;
 		}
 		skp->Text(CW, 2 * H / 14, Buffer, strlen(Buffer));
-		if (GC->MissionPlanningActive)
+		if (GD->MissionPlanningActive)
 		{
 			GET_Display(Buffer, GC->rtcc->PZMCCPLN.VectorGET);
 		}
@@ -2165,7 +2159,7 @@ bool ApolloRTCCMFD::Update(oapi::Sketchpad *skp)
 		{
 			skp->Text(CW, 4 * H / 14, "Chaser: LM", 10);
 		}
-		if (GC->MissionPlanningActive)
+		if (GD->MissionPlanningActive)
 		{
 			GET_Display2(Buffer, GC->rtcc->med_k15.CSMVectorTime);
 		}
@@ -2816,7 +2810,7 @@ bool ApolloRTCCMFD::Update(oapi::Sketchpad *skp)
 				skp->Text(W - CW, 4 * H / 14, Buffer, strlen(Buffer));
 			}
 		}
-		if (GC->MissionPlanningActive)
+		if (GD->MissionPlanningActive)
 		{
 			//Chaser and target vector IDs
 			skp->Text(W - CW, 8 * H / 14, GC->rtcc->med_k10.ChaserVectorID.c_str(), GC->rtcc->med_k10.ChaserVectorID.size());
@@ -2896,7 +2890,7 @@ bool ApolloRTCCMFD::Update(oapi::Sketchpad *skp)
 			else Text(skp, x + dx, y, "1: Second maneuver time fixed");
 			y++;
 			Text(skp, x, y, "CVT:");
-			if (GC->MissionPlanningActive)
+			if (GD->MissionPlanningActive)
 			{
 				if (GC->rtcc->med_k32.ChaserVectorTime > 0) Text_GET_HHHMMSSCS(skp, x + dx, y, GC->rtcc->med_k32.ChaserVectorTime);
 				else Text(skp, x + dx, y, "Present Time");
@@ -2909,7 +2903,7 @@ bool ApolloRTCCMFD::Update(oapi::Sketchpad *skp)
 				Text(skp, x + dx, y, Buffer); y++;
 			}
 			Text(skp, x, y, "TVT:");
-			if (GC->MissionPlanningActive)
+			if (GD->MissionPlanningActive)
 			{
 				if (GC->rtcc->med_k32.TargetVectorTime > 0) Text_GET_HHHMMSSCS(skp, x + dx, y, GC->rtcc->med_k32.TargetVectorTime);
 				else Text(skp, x + dx, y, "Present Time");
@@ -3000,7 +2994,7 @@ bool ApolloRTCCMFD::Update(oapi::Sketchpad *skp)
 		skp->SetTextAlign(oapi::Sketchpad::CENTER);
 		skp->Text(W / 2, CH / 2, "Lunar Ascent Processor", 22);
 		skp->SetTextAlign(oapi::Sketchpad::LEFT);
-		GET_Display2(Buffer, G->t_LunarLiftoff);
+		GET_Display2(Buffer, GD->t_LunarLiftoff);
 		skp->Text(CW, 2 * H / 14, Buffer, strlen(Buffer));
 		sprintf(Buffer, "%+07.1f ft/s", GC->rtcc->PZLTRT.InsertionHorizontalVelocity / 0.3048);
 		skp->Text(CW, 4 * H / 14, Buffer, strlen(Buffer));
@@ -3037,7 +3031,7 @@ bool ApolloRTCCMFD::Update(oapi::Sketchpad *skp)
 		skp->Text(W - CW * 17, CH * 23, "ZD", 2);
 		skp->Text(W - CW * 17, CH * 24, "T", 1);
 		skp->SetTextAlign(oapi::Sketchpad::RIGHT);
-		if (!GC->MissionPlanningActive)
+		if (!GD->MissionPlanningActive)
 		{
 			PrintLMVessel(Buffer);
 			skp->Text(W - CW, 2 * H / 14, Buffer, strlen(Buffer));
@@ -3073,7 +3067,7 @@ bool ApolloRTCCMFD::Update(oapi::Sketchpad *skp)
 		}
 		skp->Text(CW, 2 * H / 14, Buffer, strlen(Buffer));
 
-		OrbMech::SStoHHMMSS(G->t_LunarLiftoff, hh, mm, secs, 0.01);
+		OrbMech::SStoHHMMSS(GD->t_LunarLiftoff, hh, mm, secs, 0.01);
 		Text(skp, 12, 11, "%+06d HRS", hh);
 		Text(skp, 12, 12, "%+06d MIN TIG", mm);
 		Text(skp, 12, 13, "%+07.2f SEC", secs);
@@ -3118,7 +3112,7 @@ bool ApolloRTCCMFD::Update(oapi::Sketchpad *skp)
 				else Text(skp, x + dx, y, "APS");
 			}
 			y++;
-			if (GC->MissionPlanningActive)
+			if (GD->MissionPlanningActive)
 			{
 				Text(skp, x, y, "CVT:");
 				Text_GET_HHHMMSSCS(skp, x + dx, y, GC->PDAP_CSM_VectorTime);
@@ -3130,7 +3124,7 @@ bool ApolloRTCCMFD::Update(oapi::Sketchpad *skp)
 				Text(skp, x + dx, y, Buffer);
 			}
 			y++;
-			if (GC->MissionPlanningActive)
+			if (GD->MissionPlanningActive)
 			{
 				Text(skp, x, y, "LVT:");
 				Text_GET_HHHMMSSCS(skp, x + dx, y, GC->PDAP_LM_VectorTime);
@@ -3595,7 +3589,7 @@ bool ApolloRTCCMFD::Update(oapi::Sketchpad *skp)
 		SetMOCRFont(skp, 3, false);
 		GetCharSize(skp, CW, CH);
 		SetMOCRDisplayCentered(3);
-		if (GC->MissionPlanningActive)
+		if (GD->MissionPlanningActive)
 		{
 			G->CycleSpaceDigitals();
 		}
@@ -3762,7 +3756,7 @@ bool ApolloRTCCMFD::Update(oapi::Sketchpad *skp)
 		SetMOCRFont(skp, 3, false);
 		GetCharSize(skp, CW, CH);
 		SetMOCRDisplayCentered(3);
-		if (GC->MissionPlanningActive)
+		if (GD->MissionPlanningActive)
 		{
 			skp->Text(CW, CH / 2, "Active", 6);
 		}
@@ -4086,7 +4080,7 @@ bool ApolloRTCCMFD::Update(oapi::Sketchpad *skp)
 		SetMOCRFont(skp, 4, false);
 		Text(skp, 13, 1, "%04d", tab->SequenceNumber);
 		Text_GET_HHHMMSS(skp, 31, 1, tab->GETofGeneration);
-		if (GC->MissionPlanningActive)
+		if (GD->MissionPlanningActive)
 		{
 			Text(skp, 15, 2, tab->DCCode);
 		}
@@ -4259,7 +4253,7 @@ bool ApolloRTCCMFD::Update(oapi::Sketchpad *skp)
 		{
 			Text(skp, 22, 4 + i, "%05d", tab->Octals[i]);
 		}
-		if (GC->MissionPlanningActive)
+		if (GD->MissionPlanningActive)
 		{
 			Text(skp, 40, 6, "%+.1f", tab->DV.x);
 			Text(skp, 40, 8, "%+.1f", tab->DV.y);
@@ -4406,7 +4400,7 @@ bool ApolloRTCCMFD::Update(oapi::Sketchpad *skp)
 	break;
 	case 54:
 	{
-		int num = (GC->MissionPlanningActive ? subscreen : 0);
+		int num = (GD->MissionPlanningActive ? subscreen : 0);
 
 		skp->SetTextAlign(oapi::Sketchpad::CENTER);
 		skp->Text(W / 2, CH / 2, "Two Impulse Transfer (MED M72)", 30);
@@ -4422,14 +4416,14 @@ bool ApolloRTCCMFD::Update(oapi::Sketchpad *skp)
 		y++;
 		Text(skp, x, y, "PLN:");
 		Text(skp, x + dx, y, "%d", GC->rtcc->med_m72.Plan); y++;
-		if (GC->MissionPlanningActive)
+		if (GD->MissionPlanningActive)
 		{
 			Text(skp, x, y, "DEL:");
 			if (GC->rtcc->med_m72.DeleteGET > 0) Text_GET_HHHMMSSCS(skp, x + dx, y, GC->rtcc->med_m72.DeleteGET);
 			else Text(skp, x + dx, y, "Do not delete");
 		}
 		y++;
-		if (GC->MissionPlanningActive)
+		if (GD->MissionPlanningActive)
 		{
 			Text(skp, x, y, "MAN:");
 			Text(skp, x + dx, y, "Inputs for maneuver %d", subscreen + 1);
@@ -4438,7 +4432,7 @@ bool ApolloRTCCMFD::Update(oapi::Sketchpad *skp)
 		Text(skp, x, y, "THR:");
 		ThrusterName(Buffer, GC->rtcc->med_m72.ManData[num].Thruster);
 		Text(skp, x + dx, y, Buffer); y++;
-		if (GC->MissionPlanningActive)
+		if (GD->MissionPlanningActive)
 		{
 			Text(skp, x, y, "ATT:");
 			MPTAttitudeName(Buffer, GC->rtcc->med_m72.ManData[num].Attitude);
@@ -4464,13 +4458,13 @@ bool ApolloRTCCMFD::Update(oapi::Sketchpad *skp)
 		if (GC->rtcc->med_m72.ManData[num].TimeFlag) Text(skp, x + dx, y, "Impulsive TIG");
 		else Text(skp, x + dx, y, "Optimum TIG");
 		y++;
-		if (GC->MissionPlanningActive)
+		if (GD->MissionPlanningActive)
 		{
 			Text(skp, x, y, "SAV:");
 			Text(skp, x + dx, y, "Use for all maneuvers");
 		}
 		skp->SetTextAlign(oapi::Sketchpad::RIGHT);
-		if (GC->MissionPlanningActive == false)
+		if (GD->MissionPlanningActive == false)
 		{
 			GET_Display2(Buffer, G->P30TIG);
 			skp->Text(W - CW, H - CH * 5, Buffer, strlen(Buffer));
@@ -4490,7 +4484,7 @@ bool ApolloRTCCMFD::Update(oapi::Sketchpad *skp)
 		break;
 	case 55:
 	{
-		int num = (GC->MissionPlanningActive ? subscreen : 0);
+		int num = (GD->MissionPlanningActive ? subscreen : 0);
 
 		skp->SetTextAlign(oapi::Sketchpad::CENTER);
 		skp->Text(W / 2, CH / 2, "Transfer DKI, SPQ, or a Descent Plan", 36);
@@ -4504,14 +4498,14 @@ bool ApolloRTCCMFD::Update(oapi::Sketchpad *skp)
 		else if (GC->rtcc->med_m70.Plan < 0) Text(skp, x + dx, y, "Descent Plan");
 		else Text(skp, x + dx, y, "DKI Plan %d", GC->rtcc->med_m70.Plan);
 		y++;
-		if (GC->MissionPlanningActive)
+		if (GD->MissionPlanningActive)
 		{
 			Text(skp, x, y, "DEL:");
 			if (GC->rtcc->med_m70.DeleteGET > 0) Text_GET_HHHMMSSCS(skp, x + dx, y, GC->rtcc->med_m70.DeleteGET);
 			else Text(skp, x + dx, y, "Do not delete");
 		}
 		y++;
-		if (GC->MissionPlanningActive)
+		if (GD->MissionPlanningActive)
 		{
 			Text(skp, x, y, "MAN:");
 			Text(skp, x + dx, y, "Inputs for maneuver %d", subscreen + 1);
@@ -4520,7 +4514,7 @@ bool ApolloRTCCMFD::Update(oapi::Sketchpad *skp)
 		Text(skp, x, y, "THR:");
 		ThrusterName(Buffer, GC->rtcc->med_m70.ManData[num].Thruster);
 		Text(skp, x + dx, y, Buffer); y++;
-		if (GC->MissionPlanningActive)
+		if (GD->MissionPlanningActive)
 		{
 			Text(skp, x, y, "ATT:");
 			MPTAttitudeName(Buffer, GC->rtcc->med_m70.ManData[num].Attitude);
@@ -4546,13 +4540,13 @@ bool ApolloRTCCMFD::Update(oapi::Sketchpad *skp)
 		if (GC->rtcc->med_m70.ManData[num].TimeFlag) Text(skp, x + dx, y, "Impulsive TIG");
 		else Text(skp, x + dx, y, "Optimum TIG");
 		y++;
-		if (GC->MissionPlanningActive)
+		if (GD->MissionPlanningActive)
 		{
 			Text(skp, x, y, "SAV:");
 			Text(skp, x + dx, y, "Use for all maneuvers");
 		}
 		skp->SetTextAlign(oapi::Sketchpad::RIGHT);
-		if (GC->MissionPlanningActive == false)
+		if (GD->MissionPlanningActive == false)
 		{
 			GET_Display2(Buffer, G->P30TIG);
 			skp->Text(W - CW, H - CH * 5, Buffer, strlen(Buffer));
@@ -4691,7 +4685,7 @@ bool ApolloRTCCMFD::Update(oapi::Sketchpad *skp)
 		{
 			skp->Text(CW, 2 * H / 14, "LEM", 3);
 		}
-		if (GC->MissionPlanningActive)
+		if (GD->MissionPlanningActive)
 		{
 			if (GC->rtcc->med_m65.ReplaceCode == 0)
 			{
@@ -4735,7 +4729,7 @@ bool ApolloRTCCMFD::Update(oapi::Sketchpad *skp)
 		{
 			skp->Text(W - CW, 8 * H / 14, "Optimum TIG", 11);
 		}
-		if (GC->MissionPlanningActive == false)
+		if (GD->MissionPlanningActive == false)
 		{
 			GET_Display2(Buffer, G->P30TIG);
 			skp->Text(W - CW, H - CH * 5, Buffer, strlen(Buffer));
@@ -5393,9 +5387,9 @@ bool ApolloRTCCMFD::Update(oapi::Sketchpad *skp)
 	case 64: //FDO Launch Analog No. 1
 		if (oapiGetSimTime() > GC->rtcc->fdolaunchanalog1tab.LastUpdateTime + 0.5)
 		{
-			if (GC->rtcc->pCSM)
+			if (GD->pCSM)
 			{
-				EphemerisData sv = GC->rtcc->StateVectorCalcEphem(GC->rtcc->pCSM);
+				EphemerisData sv = GC->rtcc->StateVectorCalcEphem(GD->pCSM);
 				GC->rtcc->FDOLaunchAnalog1(sv);
 			}
 		}
@@ -5503,9 +5497,9 @@ bool ApolloRTCCMFD::Update(oapi::Sketchpad *skp)
 	case 65: //FDO Launch Analog No. 2
 		if (oapiGetSimTime() > GC->rtcc->fdolaunchanalog2tab.LastUpdateTime + 0.5)
 		{
-			if (GC->rtcc->pCSM)
+			if (GD->pCSM)
 			{
-				EphemerisData sv = GC->rtcc->StateVectorCalcEphem(GC->rtcc->pCSM);
+				EphemerisData sv = GC->rtcc->StateVectorCalcEphem(GD->pCSM);
 				GC->rtcc->FDOLaunchAnalog2(sv);
 			}
 		}
@@ -6151,7 +6145,7 @@ bool ApolloRTCCMFD::Update(oapi::Sketchpad *skp)
 		{
 			skp->Text(CW, 2 * H / 14, "LEM", 3);
 		}
-		if (GC->MissionPlanningActive)
+		if (GD->MissionPlanningActive)
 		{
 			if (GC->rtcc->med_m78.ReplaceCode == 0)
 			{
@@ -6165,7 +6159,7 @@ bool ApolloRTCCMFD::Update(oapi::Sketchpad *skp)
 		Text_Int(skp, CW, 6 * H / 14, "%d", GC->rtcc->med_m78.ManeuverNumber);
 		ThrusterName(Buffer, GC->rtcc->med_m78.ManData.Thruster);
 		skp->Text(CW, 8 * H / 14, Buffer, strlen(Buffer));
-		if (GC->MissionPlanningActive)
+		if (GD->MissionPlanningActive)
 		{
 			MPTAttitudeName(Buffer, GC->rtcc->med_m78.ManData.Attitude);
 			skp->Text(CW, 10 * H / 14, Buffer, strlen(Buffer));
@@ -6194,7 +6188,7 @@ bool ApolloRTCCMFD::Update(oapi::Sketchpad *skp)
 		{
 			skp->Text(W - CW, 8 * H / 14, "Optimum TIG", 11);
 		}
-		if (GC->MissionPlanningActive == false)
+		if (GD->MissionPlanningActive == false)
 		{
 			GET_Display2(Buffer, G->P30TIG);
 			skp->Text(W - CW, H - CH * 5, Buffer, strlen(Buffer));
@@ -6396,7 +6390,7 @@ bool ApolloRTCCMFD::Update(oapi::Sketchpad *skp)
 		}
 		skp->Text(CW * 10, 3 * H / 22, Buffer, strlen(Buffer));
 
-		if (GC->MissionPlanningActive)
+		if (GD->MissionPlanningActive)
 		{
 			skp->Text(CW * 2, 4 * H / 22, "MPT:", 4);
 			if (GC->rtcc->PZTLIPLN.mpt == RTCC_MPT_CSM)
@@ -7152,7 +7146,7 @@ bool ApolloRTCCMFD::Update(oapi::Sketchpad *skp)
 		TextW(skp, 42, 25, L"H\u209AT");
 		skp->SetTextAlign(oapi::Sketchpad::RIGHT);
 		SetMOCRFont(skp, 3, true);
-		if (GC->MissionPlanningActive)
+		if (GD->MissionPlanningActive)
 		{
 			Text(skp, 19, 1, GC->rtcc->PZLLTT.CSM_STA_ID);
 		}
@@ -7203,7 +7197,7 @@ bool ApolloRTCCMFD::Update(oapi::Sketchpad *skp)
 		skp->SetTextAlign(oapi::Sketchpad::CENTER);
 		skp->Text(W / 2, CH / 2, "TPI TIMES", 9);
 		skp->SetTextAlign(oapi::Sketchpad::LEFT);
-		if (GC->MissionPlanningActive)
+		if (GD->MissionPlanningActive)
 		{
 			if (G->Rendezvous_Target_Table == RTCC_MPT_CSM)
 			{
@@ -7238,7 +7232,7 @@ bool ApolloRTCCMFD::Update(oapi::Sketchpad *skp)
 		}
 		GET_Display(Buffer, G->t_TPIguess, false);
 		skp->Text(CW, 8 * H / 14, Buffer, strlen(Buffer));
-		GET_Display(Buffer, GC->t_TPI, false);
+		GET_Display(Buffer, GD->t_TPI, false);
 		skp->Text(CW, 10 * H / 14, Buffer, strlen(Buffer));
 		break;
 	case 93:
@@ -7960,7 +7954,7 @@ bool ApolloRTCCMFD::Update(oapi::Sketchpad *skp)
 		//4: Entry Profile
 		//6: Miss Distance (F76 and F77, PTP only)
 		//8: Inclination (F77)
-		if (GC->MissionPlanningActive)
+		if (GD->MissionPlanningActive)
 		{
 			GET_Display(Buffer, GC->rtcc->med_f75_f77.T_V, false);
 		}
@@ -8093,7 +8087,7 @@ bool ApolloRTCCMFD::Update(oapi::Sketchpad *skp)
 		skp->SetTextAlign(oapi::Sketchpad::CENTER);
 		skp->Text(W / 2, CH / 2, "RTE Digitals Manual Maneuver Input", 26);
 		skp->SetTextAlign(oapi::Sketchpad::LEFT);
-		if (GC->MissionPlanningActive)
+		if (GD->MissionPlanningActive)
 		{
 			GET_Display(Buffer, GC->rtcc->med_f81.VectorTime, false);
 			skp->Text(CW, 2 * H / 14, Buffer, strlen(Buffer));
@@ -8571,7 +8565,7 @@ bool ApolloRTCCMFD::Update(oapi::Sketchpad *skp)
 				sprintf(Buffer, "LEM");
 			}
 			skp->Text(CW * x, y * H / 22, Buffer, strlen(Buffer)); y++;
-			if (GC->MissionPlanningActive)
+			if (GD->MissionPlanningActive)
 			{
 				if (GC->rtcc->PZSLVCON.TargetVectorTime < 0.0)
 				{
@@ -8915,7 +8909,7 @@ bool ApolloRTCCMFD::Update(oapi::Sketchpad *skp)
 			sprintf(Buffer, "LEM");
 		}
 		skp->Text(CW, 2 * H / 14, Buffer, strlen(Buffer));
-		if (GC->MissionPlanningActive)
+		if (GD->MissionPlanningActive)
 		{
 			GET_Display(Buffer, GC->rtcc->med_k28.VectorTime, false);
 		}
@@ -10268,15 +10262,15 @@ void ApolloRTCCMFD::CSMOrLMSelectionErrorMessage(oapi::Sketchpad*skp)
 
 void ApolloRTCCMFD::PrintCSMVessel(char *Buffer, bool ShowCSM)
 {
-	if (GC->rtcc->pCSM != NULL)
+	if (GD->pCSM != NULL)
 	{
 		if (ShowCSM)
 		{
-			sprintf_s(Buffer, 127, "CSM: %s", GC->rtcc->pCSM->GetName());
+			sprintf_s(Buffer, 127, "CSM: %s", GD->pCSM->GetName());
 		}
 		else
 		{
-			sprintf_s(Buffer, 127, GC->rtcc->pCSM->GetName());
+			sprintf_s(Buffer, 127, GD->pCSM->GetName());
 		}
 	}
 	else
@@ -10287,15 +10281,15 @@ void ApolloRTCCMFD::PrintCSMVessel(char *Buffer, bool ShowCSM)
 
 void ApolloRTCCMFD::PrintLMVessel(char *Buffer, bool ShowLM)
 {
-	if (GC->rtcc->pLM != NULL)
+	if (GD->pLM != NULL)
 	{
 		if (ShowLM)
 		{
-			sprintf_s(Buffer, 127, "LM: %s", GC->rtcc->pLM->GetName());
+			sprintf_s(Buffer, 127, "LM: %s", GD->pLM->GetName());
 		}
 		else
 		{
-			sprintf_s(Buffer, 127, GC->rtcc->pLM->GetName());
+			sprintf_s(Buffer, 127, GD->pLM->GetName());
 		}
 	}
 	else


### PR DESCRIPTION
Scenarios permanently save parameters now whenever the RTCC MFD module is activated in the Orbiter launchpad. These parameters currently are:

-MPT active/inactive flag
-CSM and LM vessel names (previous saved in RTCC class)
-Time of lunar liftoff
-Sextant star check time for Maneuver PADs
-TPI time

Every other kind of RTCC MFD saving that previously existed (but only worked when the MFD was open at scenario exit on the 2D panel or glass cockpit) has been removed.