### PR TITLE
Implement RTCC expendable weights table

### DIFF
--- a/Orbitersdk/samples/ProjectApollo/src_launch/rtcc.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_launch/rtcc.cpp
@@ -1769,6 +1769,37 @@ void RTCC::GMEDSaveTable::LoadState(FILEHANDLE scn, char* end_str)
 	}
 }
 
+void RTCC::ExpendableWeightsTable::SaveState(FILEHANDLE scn, char* start_str, char* end_str)
+{
+	char buffer[256];
+
+	oapiWriteLine(scn, start_str);
+
+	for (unsigned int i = 0; i < data.size(); i++)
+	{
+		sprintf_s(buffer, "%lf %lf %d", data[i].GET, data[i].WeightLoss, data[i].Veh);
+		oapiWriteScenario_string(scn, "Entry", buffer);
+	}
+
+	oapiWriteLine(scn, end_str);
+}
+
+void RTCC::ExpendableWeightsTable::LoadState(FILEHANDLE scn, char* end_str)
+{
+	char* line;
+	ExpendableWeightsTableEntry temp;
+
+	while (oapiReadScenario_nextline(scn, line)) {
+		if (!strnicmp(line, end_str, sizeof(end_str))) {
+			break;
+		}
+		if (sscanf_s(line + 5, "%lf %lf %d", &temp.GET, &temp.WeightLoss, &temp.Veh) == 3)
+		{
+			data.push_back(temp);
+		}
+	}
+}
+
 RTCC::RTCC() :
 	pmmlaeg(this)
 {
@@ -6774,6 +6805,8 @@ void RTCC::SaveState(FILEHANDLE scn) {
 
 	PZMPTCSM.SaveState(scn, "MPTCSM_BEGIN", "MPTCSM_END");
 	PZMPTLEM.SaveState(scn, "MPTLEM_BEGIN", "MPTLEM_END");
+	if (PZEXPCSM.data.size() > 0U) PZEXPCSM.SaveState(scn, "PZEXPCSM_BEGIN", "PZEXPCSM_END");
+	if (PZEXPLEM.data.size() > 0U) PZEXPLEM.SaveState(scn, "PZEXPLEM_BEGIN", "PZEXPLEM_END");
 	RZDBSC1.SaveState(scn, "RZDBSC1_BEGIN", "RZDBSC1_END");
 	PZMARM.SaveState(scn, "PZMARM_BEGIN", "PZMARM_END");
 	RZJCTTC.SaveState(scn, "RZJCTTC_BEGIN", "RZJCTTC_END");
@@ -7108,6 +7141,12 @@ void RTCC::LoadState(FILEHANDLE scn) {
 		}
 		else if (!strnicmp(line, "MPTLEM_BEGIN", sizeof("MPTLEM_BEGIN"))) {
 			PZMPTLEM.LoadState(scn, "MPTLEM_END");
+		}
+		else if (!strnicmp(line, "PZEXPCSM_BEGIN", sizeof("PZEXPCSM_BEGIN"))) {
+			PZEXPCSM.LoadState(scn, "PZEXPCSM_END");
+		}
+		else if (!strnicmp(line, "PZEXPLEM_BEGIN", sizeof("PZEXPLEM_BEGIN"))) {
+			PZEXPLEM.LoadState(scn, "PZEXPLEM_END");
 		}
 		else if (!strnicmp(line, "RZDBSC1_BEGIN", sizeof("RZDBSC1_BEGIN"))) {
 			RZDBSC1.LoadState(scn, "RZDBSC1_END");
@@ -31589,6 +31628,169 @@ int RTCC::PMMMED(std::string med, std::vector<std::string> data)
 			}
 			PZBURN.P4_DV = dv * 0.3048;
 		}
+	}
+	// Input of expendable weights
+	else if (med == "47")
+	{
+		if (data.size() < 3)
+		{
+			return 1;
+		}
+
+		int Table;
+
+		if (data[0] == "CSM")
+		{
+			Table = RTCC_MPT_CSM;
+		}
+		else if (data[0] == "LEM")
+		{
+			Table = RTCC_MPT_LM;
+		}
+		else
+		{
+			return 2;
+		}
+
+		int ActionCode;
+
+		if (data[1] == "A")
+		{
+			// Add
+			ActionCode = 0;
+		}
+		else if (data[1] == "R")
+		{
+			// Replace
+			ActionCode = 1;
+		}
+		else if (data[1] == "D")
+		{
+			// Delete
+			ActionCode = 2;
+		}
+		else
+		{
+			return 2;
+		}
+
+		ExpendableWeightsTable* tab;
+
+		if (Table == RTCC_MPT_CSM)
+		{
+			tab = &PZEXPCSM;
+		}
+		else
+		{
+			tab = &PZEXPLEM;
+		}
+
+		double Time, WeightLoss;
+		unsigned int EntryNumber;
+		int VEH;
+
+		// Read data
+		if (ActionCode != 2)
+		{
+			if (data.size() < 6)
+			{
+				return 1;
+			}
+			if (rtcc::MEDTimeInputHHMMSS(data[3], Time))
+			{
+				return 2;
+			}
+			Time *= 3600.0;
+
+			if (sscanf(data[4].c_str(), "%lf", &WeightLoss) != 1)
+			{
+				return 2;
+			}
+			WeightLoss *= 0.45359237;
+
+			if (data[5] == "C")
+			{
+				VEH = 0;
+			}
+			else if (data[5] == "S")
+			{
+				VEH = 1;
+			}
+			else if (data[5] == "A")
+			{
+				VEH = 2;
+			}
+			else if (data[5] == "D")
+			{
+				VEH = 3;
+			}
+			else
+			{
+				return 2;
+			}
+		}
+
+		if (ActionCode == 0)
+		{
+			// Add
+			if (tab->data.size() >= 20)
+			{
+				return 2;
+			}
+			ExpendableWeightsTableEntry entry;
+
+			entry.GET = Time;
+			entry.Veh = VEH;
+			entry.WeightLoss = WeightLoss;
+
+			tab->data.push_back(entry);
+		}
+		else if (ActionCode == 1)
+		{
+			// Replace
+			if (sscanf(data[2].c_str(), "%d", &EntryNumber) != 1)
+			{
+				return 2;
+			}
+
+			if (EntryNumber < 1U || EntryNumber > tab->data.size())
+			{
+				return 2;
+			}
+
+			ExpendableWeightsTableEntry entry;
+
+			entry.GET = Time;
+			entry.Veh = VEH;
+			entry.WeightLoss = WeightLoss;
+
+			tab->data[EntryNumber - 1U] = entry;
+		}
+		else
+		{
+			// Delete
+			if (sscanf(data[2].c_str(), "%d", &EntryNumber) != 1)
+			{
+				return 2;
+			}
+
+			if (EntryNumber < 0 || EntryNumber > tab->data.size())
+			{
+				return 2;
+			}
+
+			if (EntryNumber == 0)
+			{
+				// Delete all
+				tab->data.clear();
+			}
+			else
+			{
+				tab->data.erase(tab->data.begin() + (EntryNumber - 1U));
+			}
+		}
+		// Perform trajectory update
+		PMSVCT(8, Table);
 	}
 	//Change fuel remaining for specified thruster
 	else if (med == "49")

--- a/Orbitersdk/samples/ProjectApollo/src_launch/rtcc.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_launch/rtcc.cpp
@@ -36997,22 +36997,34 @@ void RTCC::PMMDMT(int L, unsigned man, RTCCNIAuxOutputTable *aux)
 		F = mptman->CommonBlock.SIVBFuelRemaining;
 	}
 
-	//Mass Maintenance
+	// Areas maintenance
 	for (int i = 0; i < 4; i++)
 	{
 		if (mptman->CommonBlock.ConfigCode[i])
 		{
-			mptman->CommonBlock.Masses[i] = CommonBlockBefore->Masses[i];
 			mptman->CommonBlock.Areas[i] = CommonBlockBefore->Areas[i];
 		}
 		else
 		{
-			mptman->CommonBlock.Masses[i] = 0.0;
 			mptman->CommonBlock.Areas[i] = 0.0;
 		}
 	}
 
-	//Account for mass loss
+	// Preburn mass maintenance
+	mptman->CommonBlock.Masses[0] = aux->W_CSM;
+	mptman->CommonBlock.Masses[1] = aux->W_SIVB;
+	mptman->CommonBlock.Masses[2] = aux->W_LMA;
+	mptman->CommonBlock.Masses[3] = aux->W_LMD;
+
+	for (int i = 0; i < 4; i++)
+	{
+		if (!(mptman->CommonBlock.ConfigCode[i]))
+		{
+			mptman->CommonBlock.Masses[i] = 0.0;
+		}
+	}
+
+	//Account for mass loss during burn
 	if (mptman->TVC == RTCC_MANVEHICLE_CSM)
 	{
 		mptman->CommonBlock.CSMMass = aux->W_CSM - aux->MainFuelUsed - aux->RCSFuelUsed;

--- a/Orbitersdk/samples/ProjectApollo/src_launch/rtcc.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_launch/rtcc.cpp
@@ -25084,12 +25084,21 @@ void RTCC::PMDDMT(int MPT_ID, unsigned ManNo, int REFSMMAT_ID, bool HeadsUp, Det
 		}
 	}
 
+	PLAWDTInput in;
+	PLAWDTOutput out;
+
+	in.TableCode = MPT_ID;
+	in.T_UP = table->TimeToBeginManeuver[ManNo - 1];
+	in.VentingOpt = true;
+
+	PLAWDT(in, out);
+
+	res.WT = out.ConfigWeight / 0.45359237;
+	res.WC = out.CSMWeight / 0.45359237;
+	res.WL = (out.LMAscWeight + out.LMDscWeight) / 0.45359237;
+
 	if (ManNo == 1)
 	{
-		res.WT = table->TotalInitMass / 0.45359237;
-		res.WC = table->CommonBlock.CSMMass / 0.45359237;
-		res.WL = (table->CommonBlock.LMAscentMass + table->CommonBlock.LMDescentMass) / 0.45359237;
-
 		switch (man->Thruster)
 		{
 		case RTCC_ENGINETYPE_CSMSPS:
@@ -25123,9 +25132,6 @@ void RTCC::PMDDMT(int MPT_ID, unsigned ManNo, int REFSMMAT_ID, bool HeadsUp, Det
 	}
 	else
 	{
-		res.WT = table->mantable[ManNo - 2].TotalMassAfter / 0.45359237;
-		res.WC = table->mantable[ManNo - 2].CommonBlock.CSMMass / 0.45359237;
-		res.WL = (table->mantable[ManNo - 2].CommonBlock.LMAscentMass + table->mantable[ManNo - 2].CommonBlock.LMDescentMass) / 0.45359237;
 		switch (man->Thruster)
 		{
 		case RTCC_ENGINETYPE_CSMSPS:

--- a/Orbitersdk/samples/ProjectApollo/src_launch/rtcc.h
+++ b/Orbitersdk/samples/ProjectApollo/src_launch/rtcc.h
@@ -3507,6 +3507,21 @@ public:
 	LWPInputTable PZSLVCON;
 	SLVTargetingParametersTable PZSLVTAR;
 
+	struct ExpendableWeightsTableEntry
+	{
+		double GET;
+		double WeightLoss;
+		int Veh; // 0 = CSM, 1 = S-IVB, 2 = LM Ascent Stage, 3 = LM Descent Stage
+	};
+
+	struct ExpendableWeightsTable
+	{
+		void SaveState(FILEHANDLE scn, char* start_str, char* end_str);
+		void LoadState(FILEHANDLE scn, char* end_str);
+
+		std::vector<ExpendableWeightsTableEntry> data;
+	} PZEXPCSM, PZEXPLEM;
+
 	struct PerigeeAdjustTableEntry
 	{
 		double Pitch = 0.0;

--- a/Orbitersdk/samples/ProjectApollo/src_rtccmfd/ARCore.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_rtccmfd/ARCore.cpp
@@ -3245,44 +3245,29 @@ int ARCore::subThread()
 				break;
 			}
 
-			MPTVehicleDataBlock *CommonBlock;
-
 			//Load data
 			sv_A.R = man->R_1;
 			sv_A.V = man->V_1;
 			sv_A.GMT = man->GMT_1;
 			sv_A.RBI = man->RefBodyInd;
 
-			if (num == 0)
+			PLAWDTInput in;
+			PLAWDTOutput out;
+
+			in.TableCode = ManPADMPT;
+			in.T_UP = mpt->TimeToBeginManeuver[num];
+			in.KFactorOpt = true;
+			in.VentingOpt = true;
+
+			GC->rtcc->PLAWDT(in, out);
+
+			if (out.Err)
 			{
-				CommonBlock = &mpt->CommonBlock;
-			}
-			else
-			{
-				CommonBlock = &mpt->mantable[num - 1].CommonBlock;
+				Result = DONE;
+				break;
 			}
 
-			WeightsTable.CC = CommonBlock->ConfigCode;
-			WeightsTable.CSMArea = CommonBlock->CSMArea;
-			WeightsTable.CSMWeight = CommonBlock->CSMMass;
-			WeightsTable.KFactor = mpt->KFactor;
-			WeightsTable.LMAscArea = CommonBlock->LMAscentArea;
-			WeightsTable.LMAscWeight = CommonBlock->LMAscentMass;
-			WeightsTable.LMDscArea = CommonBlock->LMDescentArea;
-			WeightsTable.LMDscWeight = CommonBlock->LMDescentMass;
-			WeightsTable.SIVBArea = CommonBlock->SIVBArea;
-			WeightsTable.SIVBWeight = CommonBlock->SIVBMass;
-
-			if (num == 0)
-			{
-				WeightsTable.ConfigArea = mpt->ConfigurationArea;
-				WeightsTable.ConfigWeight = mpt->TotalInitMass;
-			}
-			else
-			{
-				WeightsTable.ConfigArea = mpt->mantable[num - 1].TotalAreaAfter;
-				WeightsTable.ConfigWeight = mpt->mantable[num - 1].TotalMassAfter;
-			}
+			WeightsTable = out;
 
 			P30TIG = GC->rtcc->GETfromGMT(man->GMT_BI);
 			dV_LVLH = man->dV_LVLH;

--- a/Orbitersdk/samples/ProjectApollo/src_rtccmfd/ApolloRTCCMFD.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_rtccmfd/ApolloRTCCMFD.cpp
@@ -1481,6 +1481,13 @@ void ApolloRTCCMFD::menuSetRecoveryZonesDisplayPage()
 	SelectPage(136);
 }
 
+void ApolloRTCCMFD::menuSetExpendablesTable(int subpage)
+{
+	subscreen = subpage;
+	subscreenmax = 2;
+	SelectPage(137);
+}
+
 void ApolloRTCCMFD::menuPerigeeAdjustCalc()
 {
 	G->PerigeeAdjustCalc();
@@ -2700,6 +2707,87 @@ void ApolloRTCCMFD::menuSpacecraftPointingDisplayCalc()
 	sprintf_s(Buffer, "G42,%s,%s,%s;", Buff1, Buff2, Buff3);
 
 	menuGeneralMEDRequest("Queue S/C point display. Format: G42, GET1, GET5, GETT;", Buffer);
+}
+
+void ApolloRTCCMFD::menuExpendablesTableAdd()
+{
+	bool ExpendablesTableAddInput(void* id, char* str, void* data);
+
+	oapiOpenInputBox("Add entry to table. Format: Time Weight-Loss Vehicle. Notes: Time = HHH:MM:SS, Weight-Loss = Positive is a loss, negative a gain, Vehicle = C, S, A or D", ExpendablesTableAddInput, "000:00:00 0.0 C", 30, (void*)this);
+}
+
+bool ExpendablesTableAddInput(void* id, char* str, void* data)
+{
+	return ((ApolloRTCCMFD*)data)->set_ExpendablesTabeEntry(1, str);
+}
+
+void ApolloRTCCMFD::menuExpendablesTableReplace()
+{
+	bool ExpendablesTableReplaceInput(void* id, char* str, void* data);
+
+	oapiOpenInputBox("Replace entry in table. Format: Entry-Number Time Weight-Loss Vehicle. Entry-Number = 1-20, Notes: Time = HHH:MM:SS, Weight-Loss = Positive is a loss, negative a gain, Vehicle = C, S, A or D", ExpendablesTableReplaceInput, "1 000:00:00 0.0 C", 30, (void*)this);
+}
+
+bool ExpendablesTableReplaceInput(void* id, char* str, void* data)
+{
+	return ((ApolloRTCCMFD*)data)->set_ExpendablesTabeEntry(2, str);
+}
+
+void ApolloRTCCMFD::menuExpendablesTableDelete()
+{
+	bool ExpendablesTableDeleteInput(void* id, char* str, void* data);
+
+	oapiOpenInputBox("Delete entry in table. Format: Entry-Number. Notes: Entry-Number = 1-20 or 0 to delete all entries.", ExpendablesTableDeleteInput, "1", 30, (void*)this);
+}
+
+bool ExpendablesTableDeleteInput(void* id, char* str, void* data)
+{
+	return ((ApolloRTCCMFD*)data)->set_ExpendablesTabeEntry(3, str);
+}
+
+bool ApolloRTCCMFD::set_ExpendablesTabeEntry(int type, char* str)
+{
+	char Buff1[64], Buff2[64], Buff3[64], Buff4[64], Veh[4];
+
+	if (subscreen == 0)
+	{
+		sprintf(Veh, "CSM");
+	}
+	else
+	{
+		sprintf(Veh, "LEM");
+	}
+
+	if (type == 1)
+	{
+		// Add
+		if (sscanf(str, "%s %s %s", Buff1, Buff2, Buff3) != 3)
+		{
+			return false;
+		}
+		sprintf(Buffer, "M47,%s,A,,%s,%s,%s;", Veh, Buff1, Buff2, Buff3);
+	}
+	else if (type == 2)
+	{
+		// Replace
+		if (sscanf(str, "%s %s %s %s", Buff1, Buff2, Buff3, Buff4) != 4)
+		{
+			return false;
+		}
+		sprintf(Buffer, "M47,%s,R,%s,%s,%s,%s;", Veh, Buff1, Buff2, Buff3, Buff4);
+	}
+	else
+	{
+		// Delete
+		if (sscanf(str, "%s", Buff1) != 1)
+		{
+			return false;
+		}
+		sprintf(Buffer, "M47,%s,D,%s;", Veh, Buff1);
+	}
+	GeneralMEDRequest(Buffer);
+
+	return true;
 }
 
 void ApolloRTCCMFD::menuSaveDODREFSMMAT()
@@ -7590,12 +7678,12 @@ void ApolloRTCCMFD::menuSetLLWPVectorID()
 
 void ApolloRTCCMFD::menuTMLat()
 {
-	GenericDoubleInput(&G->TMLat, "Latitude in degrees:", RAD);
+	GenericDoubleInput(&G->TMLat, "Latitude in degrees (-90 to +90):", RAD);
 }
 
 void ApolloRTCCMFD::menuTMLng()
 {
-	GenericDoubleInput(&G->TMLng, "Longitude in degrees:", RAD);
+	GenericDoubleInput(&G->TMLng, "Longitude in degrees (-180 to 180):", RAD);
 }
 
 void ApolloRTCCMFD::menuTMAzi()
@@ -9968,6 +10056,8 @@ void ApolloRTCCMFD::SelectMCCScreen(int num)
 	case 1597: menuSetSkeletonFlightPlanPage(); break;
 	case 1619: menuSetCheckoutMonitorPage(); break;
 	case 1629: menuSetOnlineMonitorPage(); break;
+	case 2321: menuSetExpendablesTable(0); break;
+	case 2322: menuSetExpendablesTable(1); break;
 	}
 }
 

--- a/Orbitersdk/samples/ProjectApollo/src_rtccmfd/ApolloRTCCMFD.h
+++ b/Orbitersdk/samples/ProjectApollo/src_rtccmfd/ApolloRTCCMFD.h
@@ -841,6 +841,11 @@ public:
 	void menuRTCCTimesInput();
 	void menuSetStarSightingTablePage();
 	void menuSetSpacecraftPointingDisplayPage();
+	void menuSetExpendablesTable(int subpage);
+	void menuExpendablesTableAdd();
+	void menuExpendablesTableReplace();
+	void menuExpendablesTableDelete();
+	bool set_ExpendablesTabeEntry(int type, char* str);
 
 	void SetMEDInputPageM75();
 	void SetMEDInputPageP13();

--- a/Orbitersdk/samples/ProjectApollo/src_rtccmfd/ApolloRTCCMFD_Display.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_rtccmfd/ApolloRTCCMFD_Display.cpp
@@ -3570,6 +3570,8 @@ bool ApolloRTCCMFD::Update(oapi::Sketchpad *skp)
 		Text(skp, x, y, "1597 SKEL FLT PLN"); y++;
 		Text(skp, x, y, "1619 CHECKO MONIT"); y++;
 		Text(skp, x, y, "1629 ONLINE MONIT"); y++;
+		Text(skp, x, y, "2321 CSM EXPENDBL"); y++;
+		Text(skp, x, y, "2322 LEM EXPENDBL"); y++;
 		skp->SetTextAlign(oapi::Sketchpad::RIGHT);
 		//TBD: Channel numbers, these could confuse people right now which number to input
 		/*
@@ -9603,6 +9605,46 @@ bool ApolloRTCCMFD::Update(oapi::Sketchpad *skp)
 			}
 		}
 		Text(skp, 35, 27, GC->rtcc->RZPAGE.ErrorMessage);
+		break;
+	case 137:
+	{
+		RTCC::ExpendableWeightsTable* tab;
+
+		SetMOCRFont(skp, 3, false);
+		GetCharSize(skp, CW, CH);
+		SetMOCRDisplayCentered(3);
+		if (subscreen == 0)
+		{
+			Text(skp, 8, 0, "CSM EXPENDABLES WEIGHT LOSS TABLE");
+			Text(skp, 52, 0, "2321");
+			tab = &GC->rtcc->PZEXPCSM;
+		}
+		else
+		{
+			Text(skp, 8, 0, "LEM EXPENDABLES WEIGHT LOSS TABLE");
+			Text(skp, 52, 0, "2322");
+			tab = &GC->rtcc->PZEXPLEM;
+		}
+		Text(skp, 1, 2, "SET     GET          GMT      WEIGHT LOSS  VEHICLE");
+		skp->SetTextAlign(oapi::Sketchpad::RIGHT);
+		SetMOCRFont(skp, 3, true);
+
+		for (unsigned int i = 0; i < tab->data.size(); i++)
+		{
+			Text(skp, 4, 4 + i, "%d", (int)(i + 1));
+			Text_GET_HHHMMSSCS(skp, 17, 4 + i, tab->data[i].GET);
+			Text_GET_HHHMMSSCS(skp, 30, 4 + i, GC->rtcc->GMTfromGET(tab->data[i].GET));
+			Text(skp, 41, 4 + i, "%.1lf", tab->data[i].WeightLoss / 0.45359237);
+			switch (tab->data[i].Veh)
+			{
+			case 0: sprintf(Buffer, "C"); break;
+			case 1: sprintf(Buffer, "S"); break;
+			case 2: sprintf(Buffer, "A"); break;
+			case 3: sprintf(Buffer, "D"); break;
+			}
+			Text(skp, 48, 4 + i, Buffer);
+		}
+	}
 		break;
 	}
 

--- a/Orbitersdk/samples/ProjectApollo/src_rtccmfd/ApollomfdButtons.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_rtccmfd/ApollomfdButtons.cpp
@@ -4658,6 +4658,40 @@ ApolloRTCCMFDButtons::ApolloRTCCMFDButtons()
 	RegisterFunction("", OAPI_KEY_K, &ApolloRTCCMFD::menuVoid);
 	RegisterFunction("", OAPI_KEY_L, &ApolloRTCCMFD::menuVoid);
 	RegisterFunction("BCK", OAPI_KEY_B, &ApolloRTCCMFD::menuSetMCCDisplaysPage);
+
+
+	static const MFDBUTTONMENU mnu137[] =
+	{
+		{ "Add entry", 0, 'A' },
+		{ "Replace entry", 0, 'R' },
+		{ "Delete entry", 0, 'D' },
+		{ "", 0, ' ' },
+		{ "", 0, ' ' },
+		{ "", 0, ' ' },
+
+		{ "", 0, ' ' },
+		{ "", 0, ' ' },
+		{ "", 0, ' ' },
+		{ "", 0, ' ' },
+		{ "", 0, ' ' },
+		{ "Back to menu", 0, 'B' },
+	};
+
+	RegisterPage(mnu137, sizeof(mnu137) / sizeof(MFDBUTTONMENU));
+
+	RegisterFunction("ADD", OAPI_KEY_A, &ApolloRTCCMFD::menuExpendablesTableAdd);
+	RegisterFunction("REP", OAPI_KEY_R, &ApolloRTCCMFD::menuExpendablesTableReplace);
+	RegisterFunction("DEL", OAPI_KEY_D, &ApolloRTCCMFD::menuExpendablesTableDelete);
+	RegisterFunction("", OAPI_KEY_U, &ApolloRTCCMFD::menuVoid);
+	RegisterFunction("", OAPI_KEY_M, &ApolloRTCCMFD::menuVoid);
+	RegisterFunction("", OAPI_KEY_O, &ApolloRTCCMFD::menuVoid);
+
+	RegisterFunction("", OAPI_KEY_C, &ApolloRTCCMFD::menuVoid);
+	RegisterFunction("", OAPI_KEY_F, &ApolloRTCCMFD::menuVoid);
+	RegisterFunction("", OAPI_KEY_P, &ApolloRTCCMFD::menuVoid);
+	RegisterFunction("", OAPI_KEY_K, &ApolloRTCCMFD::menuVoid);
+	RegisterFunction("", OAPI_KEY_L, &ApolloRTCCMFD::menuVoid);
+	RegisterFunction("BCK", OAPI_KEY_B, &ApolloRTCCMFD::menuSetMCCDisplaysPage);
 }
 
 bool ApolloRTCCMFDButtons::SearchForKeysInOtherPages() const

--- a/Orbitersdk/samples/ProjectApollo/src_rtccmfd/rtcc_library_programs.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_rtccmfd/rtcc_library_programs.cpp
@@ -1870,7 +1870,7 @@ RTCC_PLAWDT_2_D:
 		K = K - 1;
 		goto RTCC_PLAWDT_2_D;
 	}
-	T_AW = mpt->TimeToEndManeuver[K - 1];
+	T_AW = mpt->TimeToEndManeuver[K - 1] - GetGMTLO() * 3600.0;
 RTCC_PLAWDT_3_F:
 	if (CC == 0)
 	{

--- a/Orbitersdk/samples/ProjectApollo/src_rtccmfd/rtcc_library_programs.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_rtccmfd/rtcc_library_programs.cpp
@@ -1723,6 +1723,7 @@ void RTCC::PLAWDT(const PLAWDTInput &in, PLAWDTOutput &out)
 	unsigned int J, N, K, BLK;
 
 	MissionPlanTable *mpt;
+	ExpendableWeightsTable* exptab;
 
 	//No error yet...
 	out.Err = 0;
@@ -1918,9 +1919,38 @@ RTCC_PLAWDT_3_G:
 		out.CC = in.Num;
 	}
 	//Read Expendables Table
+	if (abs(in.TableCode) == RTCC_MPT_CSM)
+	{
+		exptab = &PZEXPCSM;
+	}
+	else
+	{
+		exptab = &PZEXPLEM;
+	}
+
 	//Make T_UP a GET
-	T_UP = T_UP - GetGMTLO()*3600.0;
-	//TBD: Expendables stuff
+	T_UP = T_UP - GetGMTLO() * 3600.0;
+
+	// Number of expendables?
+	if (exptab->data.size() != 0)
+	{
+		for (K = 0; K < exptab->data.size(); K++)
+		{
+			// Time in between T_AW and T_UP?
+			if (T_AW <= exptab->data[K].GET && T_UP >= exptab->data[K].GET)
+			{
+				// Yes
+				// Adjust indicated weight by weight loss
+				switch (exptab->data[K].Veh)
+				{
+				case 0: out.CSMWeight -= exptab->data[K].WeightLoss; break;
+				case 1: out.SIVBWeight -= exptab->data[K].WeightLoss; break;
+				case 2: out.LMAscWeight -= exptab->data[K].WeightLoss; break;
+				case 3: out.LMDscWeight -= exptab->data[K].WeightLoss; break;
+				}
+			}
+		}
+	}
 	dt = T_UP - T_AW;
 RTCC_PLAWDT_M_5:
 	if (CC[RTCC_CONFIG_C])


### PR DESCRIPTION
The RTCC expendable weights table is a table used to define discrete weight losses and gains for the MPT that are independent of any propulsive maneuvers. One good example would be the SIM bay door jettison on Apollo 15 to 17.