### PR TITLE
A few small RTCC improvements

### DIFF
--- a/Orbitersdk/samples/ProjectApollo/src_launch/rtcc.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_launch/rtcc.cpp
@@ -5688,8 +5688,13 @@ void RTCC::TLI_PAD(const TLIPADOpt &opt, TLIPAD &pad)
 	M = OrbMech::CALCSMSC(_V(PI - opt.SeparationAttitude.x, opt.SeparationAttitude.y, opt.SeparationAttitude.z));
 	M_RTM = mul(M, M_R);
 
+	// Separation attitude
 	SepATT = OrbMech::CALCGAR(opt.REFSMMAT, M_RTM);
+
+	// Extraction attitude
 	ExtATT = _V(300.0*RAD - SepATT.x, SepATT.y + PI, PI2 - SepATT.z);
+	// Wraparound pitch angle
+	if (ExtATT.y >= PI2) ExtATT.y -= PI2;
 
 	pad.BurnTime = AuxTableIndicator.DT_B;
 	pad.dVC = AuxTableIndicator.DV_C / 0.3048;

--- a/Orbitersdk/samples/ProjectApollo/src_rtccmfd/ARCore.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_rtccmfd/ARCore.cpp
@@ -198,6 +198,7 @@ AR_GCore::AR_GCore(AR_GlobalData* GD, VESSEL* v)
 
 	LmkLat = 0;
 	LmkLng = 0;
+	LmkAlt = 0;
 	LmkTime = 0;
 	LmkElevation = 35.0*RAD;
 	landmarkpad.T1[0] = 0;
@@ -325,6 +326,51 @@ AR_GCore::AR_GCore(AR_GlobalData* GD, VESSEL* v)
 	else
 	{
 		REFSMMAT_PTC_MJD = oapiGetSimMJD(); //Near current time usually gives a good PTC REFSMMAT, too
+	}
+
+	// Powered Descent Abort Program
+	PDAPOptions.dt_stage = 999999.9; // Staging when DPS runs out of propellant
+	if (mission == 11)
+	{
+		PDAPVersion = 0;
+		PDAPOptions.dt_CAN = 0.0;
+		PDAPOptions.DV_CAN = _V(0, 0, 0) * 0.3048;
+		PDAPOptions.dt_CSI = 50.0 * 60.0;
+	}
+	else if (mission == 12)
+	{
+		PDAPVersion = 1;
+		PDAPOptions.K4 = false;
+		PDAPOptions.dt_CAN = 0.0;
+		PDAPOptions.DV_CAN = _V(0, 0, 0) * 0.3048;
+		PDAPOptions.dt_CSI = 50.0 * 60.0;
+		PDAPOptions.dt_2CAN = 50.0 * 60.0;
+		PDAPOptions.DV_2CAN = _V(10, 0, 0) * 0.3048;
+		PDAPOptions.dt_2CSI = 110.0 * 60.0;
+	}
+	else if (mission <= 15)
+	{
+		PDAPVersion = 2;
+		PDAPOptions.K4 = true;
+		PDAPOptions.theta_TARG = -13.5 * RAD;
+		PDAPOptions.dt_CAN = 60.0 * 60.0;
+		PDAPOptions.DV_CAN = _V(10, 0, 0) * 0.3048;
+		PDAPOptions.dt_CSI = 120.0 * 60.0;
+		PDAPOptions.dt_2CAN = 0.0;
+		PDAPOptions.DV_2CAN = _V(0, 0, 0) * 0.3048;
+		PDAPOptions.dt_2CSI = 55.0 * 60.0;
+	}
+	else if (mission <= 17)
+	{
+		PDAPVersion = 2;
+		PDAPOptions.K4 = true;
+		PDAPOptions.theta_TARG = 16.0 * RAD;
+		PDAPOptions.dt_CAN = 0.0;
+		PDAPOptions.DV_CAN = _V(0, 0, 0) * 0.3048;
+		PDAPOptions.dt_CSI = 55.0 * 60.0;
+		PDAPOptions.dt_2CAN = 50.0 * 60.0;
+		PDAPOptions.DV_2CAN = _V(10, 0, 0) * 0.3048;
+		PDAPOptions.dt_2CSI = 110.0 * 60.0;
 	}
 
 	//Get a pointer to the RTCC. If the MCC vessel doesn't exist yet, create it
@@ -4437,9 +4483,10 @@ int ARCore::subThread()
 			sv0 = GC->rtcc->StateVectorCalcEphem(v);
 		}
 
-		opt.lat[0] = GC->LmkLat;
 		opt.LmkTime[0] = get;
+		opt.lat[0] = GC->LmkLat;
 		opt.lng[0] = GC->LmkLng;
+		opt.alt[0] = GC->LmkAlt;
 		opt.sv0 = sv0;
 		opt.Elevation = GC->LmkElevation;
 		opt.entries = 1;

--- a/Orbitersdk/samples/ProjectApollo/src_rtccmfd/ARCore.h
+++ b/Orbitersdk/samples/ProjectApollo/src_rtccmfd/ARCore.h
@@ -107,7 +107,7 @@ public:
 
 	//LANDMARK TRACKING PAGE
 	AP11LMARKTRKPAD landmarkpad;
-	double LmkLat, LmkLng;
+	double LmkLat, LmkLng, LmkAlt;
 	double LmkTime;
 	double LmkElevation;
 

--- a/Orbitersdk/samples/ProjectApollo/src_rtccmfd/ApolloRTCCMFD.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_rtccmfd/ApolloRTCCMFD.cpp
@@ -7420,11 +7420,17 @@ void ApolloRTCCMFD::menuSetLmkLng()
 	GenericDoubleInput(&GC->LmkLng, "Choose the landmark longitude:", "%.3lf", RAD);
 }
 
+void ApolloRTCCMFD::menuSetLmkAlt()
+{
+	GenericDoubleInput(&GC->LmkAlt, "Choose the landmark altitude (in nautical miles):", "%.2lf", 1852.0);
+}
+
 void ApolloRTCCMFD::menuLmkUseLandingSite()
 {
 	//Load RTCC stored landing site coordinates into input for P22 PAD
 	GC->LmkLat = GC->rtcc->BZLAND.lat[0];
 	GC->LmkLng = GC->rtcc->BZLAND.lng[0];
+	GC->LmkAlt = GC->rtcc->BZLAND.rad[0] - OrbMech::R_Moon;
 }
 
 void ApolloRTCCMFD::menuLSRadius()

--- a/Orbitersdk/samples/ProjectApollo/src_rtccmfd/ApolloRTCCMFD.h
+++ b/Orbitersdk/samples/ProjectApollo/src_rtccmfd/ApolloRTCCMFD.h
@@ -320,6 +320,7 @@ public:
 	void menuSetLmkElevation();
 	void menuSetLmkLat();
 	void menuSetLmkLng();
+	void menuSetLmkAlt();
 	void menuLmkUseLandingSite();
 	void menuLmkPADCalc();
 	void menuSetTargetingMenu();

--- a/Orbitersdk/samples/ProjectApollo/src_rtccmfd/ApolloRTCCMFD_Display.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_rtccmfd/ApolloRTCCMFD_Display.cpp
@@ -1734,6 +1734,8 @@ bool ApolloRTCCMFD::Update(oapi::Sketchpad *skp)
 		skp->Text(CW, 8 * H / 14, Buffer, strlen(Buffer));
 		sprintf(Buffer, "%.3f°", GC->LmkLng*DEG);
 		skp->Text(CW, 10 * H / 14, Buffer, strlen(Buffer));
+		sprintf(Buffer, "%.2lf", GC->LmkAlt / 1852.0);
+		skp->Text(CW, 12 * H / 14, Buffer, strlen(Buffer));
 		
 		GET_Display(Buffer2, GC->landmarkpad.T1[0]);
 		sprintf(Buffer, "T1: %s (HOR)", Buffer2);

--- a/Orbitersdk/samples/ProjectApollo/src_rtccmfd/ApollomfdButtons.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_rtccmfd/ApollomfdButtons.cpp
@@ -454,12 +454,12 @@ ApolloRTCCMFDButtons::ApolloRTCCMFDButtons()
 		{ "T2 elevation", 0, ' ' },
 		{ "Landmark Latitude", 0, 'A' },
 		{ "Landmark Longitude", 0, 'O' },
-		{ "Load landing site coordinates", 0, 'D' },
+		{ "Landmark Altitude", 0, 'G' },
 
 		{ "Calculate PAD", 0, 'C' },
 		{ "", 0, ' ' },
 		{ "", 0, ' ' },
-		{ "", 0, ' ' },
+		{ "Load landing site coordinates", 0, 'D' },
 		{ "", 0, ' ' },
 		{ "Back to menu", 0, 'B' },
 	};
@@ -471,10 +471,10 @@ ApolloRTCCMFDButtons::ApolloRTCCMFDButtons()
 	RegisterFunction("EL", OAPI_KEY_F, &ApolloRTCCMFD::menuSetLmkElevation);
 	RegisterFunction("LAT", OAPI_KEY_A, &ApolloRTCCMFD::menuSetLmkLat);
 	RegisterFunction("LNG", OAPI_KEY_O, &ApolloRTCCMFD::menuSetLmkLng);
-	RegisterFunction("LLS", OAPI_KEY_D, &ApolloRTCCMFD::menuLmkUseLandingSite);
+	RegisterFunction("ALT", OAPI_KEY_G, &ApolloRTCCMFD::menuSetLmkAlt);
 
 	RegisterFunction("CLC", OAPI_KEY_C, &ApolloRTCCMFD::menuLmkPADCalc);
-	RegisterFunction("", OAPI_KEY_G, &ApolloRTCCMFD::menuVoid);
+	RegisterFunction("LLS", OAPI_KEY_D, &ApolloRTCCMFD::menuLmkUseLandingSite);
 	RegisterFunction("", OAPI_KEY_H, &ApolloRTCCMFD::menuVoid);
 	RegisterFunction("", OAPI_KEY_I, &ApolloRTCCMFD::menuVoid);
 	RegisterFunction("", OAPI_KEY_J, &ApolloRTCCMFD::menuVoid);


### PR DESCRIPTION
-Fix TLI PAD extraction pitch attitude. It always showed zero if the separation pitch angle was greater than 180 degrees
-Landmark Tracking PAD in RTCC MFD now has an altitude input
-Some Powered Descent Abort Program inputs in the RTCC MFD are preloaded based on mission number