### PR TITLE
Updated LR and Quad Heater Caution Logic in CWEA

### DIFF
--- a/Orbitersdk/samples/ProjectApollo/src_lm/lm_cwea.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_lm/lm_cwea.cpp
@@ -591,10 +591,16 @@ void LEM_CWEA::Timestep(double simdt) {
 		WaterCautFF3.Set((abs(lem->scera1.GetVoltage(8, 1) - lem->scera1.GetVoltage(8, 2)) / ((lem->scera1.GetVoltage(8, 1) + lem->scera1.GetVoltage(8, 2)) / 2.0)) >= 0.15);
 		WaterCautFF3.Reset(lem->QtyMonRotary.GetState() == 0);
 
-		if ((lem->stage < 2 && (WaterCautFF1.IsSet() || WaterCautFF2.IsSet())) || WaterCautFF3.IsSet())
-			SetLight(3, 7, 1);
-		else
-			SetLight(3, 7, 0);
+		// Warning light was removed on LM-9+
+		if (lem->pMission->GetLMNumber() >= 9) {
+			SetLight(3, 7, 2);
+		}
+		else {
+			if ((lem->stage < 2 && (WaterCautFF1.IsSet() || WaterCautFF2.IsSet())) || WaterCautFF3.IsSet())
+				SetLight(3, 7, 1);
+			else
+				SetLight(3, 7, 0);
+		}
 
 		// 6DS40 S-BAND RECEIVER FAILURE CAUTION
 		// On when reciever signal lost.
@@ -614,6 +620,12 @@ void LEM_CWEA::Timestep(double simdt) {
 
 		//Only for LM10+
 		SetLight(3, 5, 2);
+
+		//Disable light for LM-9+
+		if (lem->pMission->GetLMNumber() >= 9)
+		{
+			SetLight(3, 7, 2);
+		}
 
 		//CWEA PWR
 		SetLight(3, 6, 1);
@@ -670,7 +682,8 @@ void LEM_CWEA::Timestep(double simdt) {
 		LightStatus[0][7] = 1;
 		LightStatus[1][7] = 1;
 		LightStatus[2][7] = 1;
-		LightStatus[3][7] = 1;
+		if (lem->pMission->GetLMNumber() <= 8)
+			LightStatus[3][7] = 1;
 		LightStatus[4][7] = 1;
 		break;
 	case 6: // COMPNT

--- a/Orbitersdk/samples/ProjectApollo/src_lm/lm_cwea.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_lm/lm_cwea.cpp
@@ -419,19 +419,20 @@ void LEM_CWEA::Timestep(double simdt) {
 
 		// LR Antenna
 		// LM-3: < -15.0F or > 150.0F 
-		// LM-4 and subsequent: < 15.6F or > 148.9F, cut and capped
+		// LM-4 and subsequent: < 15.6F or > 148.9F
 		if (lem->pMission->GetLMNumber() < 3)
 		{
 			min = 2.313; // -15.0F
 			max = 4.375; // 150.0F
-			voltage = lem->scera1.GetVoltage(21, 3);
 		}
 		else
 		{
 			min = 2.305; // -15.6F
 			max = 4.361; // 148.9F
-			voltage = 0.0;
 		}
+
+		// Cut and capped on LM-4 exclusively
+		lem->pMission->GetLMNumber() == 4 ? voltage = 0 : voltage = lem->scera1.GetVoltage(21, 3);
 
 		LRHeaterCautFF.Set(voltage < min || voltage > max);
 		LRHeaterCautFF.Reset(lem->TempMonitorRotary.GetState() == 1);
@@ -456,32 +457,48 @@ void LEM_CWEA::Timestep(double simdt) {
 			max = 4.703; // 241.0F
 		}
 
+		double RCSVoltage1 = 0.0;
+		double RCSVoltage2 = 0.0;
+		double RCSVoltage3 = 0.0;
+		double RCSVoltage4 = 0.0;
+
+		if (lem->pMission->GetLMNumber() <= 3)
+		{
+			RCSVoltage1 = lem->scera1.GetVoltage(20, 4);
+			RCSVoltage2 = lem->scera1.GetVoltage(20, 3);
+			RCSVoltage3 = lem->scera1.GetVoltage(20, 2);
+			RCSVoltage4 = lem->scera1.GetVoltage(20, 1);
+		}
+		else if (lem->pMission->GetLMNumber() >= 8)
+		{
+			// Constant voltage from master alarm reset circuit. Voltage unknown at this point, assumed somewhere between min and max
+			RCSVoltage1 = RCSVoltage2 = RCSVoltage3 = RCSVoltage4 = IsCWEAPowered() ? 4.0 : 0.0;
+		}
+		// Otherwise LM-4 through LM-7 remain 0.0, cut and capped
+
+
 		//Quad 1
-		voltage = lem->pMission->GetLMNumber() <= 4 ? lem->scera1.GetVoltage(20, 4) : 0.0;
-		QD1HeaterCautFF.Set(voltage < min || voltage > max);
+		QD1HeaterCautFF.Set(RCSVoltage1 < min || RCSVoltage1 > max);
 		QD1HeaterCautFF.Reset(lem->TempMonitorRotary.GetState() == 2);
 
 		//Quad 2
-		voltage = lem->pMission->GetLMNumber() <= 4 ? lem->scera1.GetVoltage(20, 3) : 0.0;
-		QD2HeaterCautFF.Set(voltage < min || voltage > max);
+		QD2HeaterCautFF.Set(RCSVoltage2 < min || RCSVoltage2 > max);
 		QD2HeaterCautFF.Reset(lem->TempMonitorRotary.GetState() == 3);
 
 		//Quad 3
-		voltage = lem->pMission->GetLMNumber() <= 4 ? lem->scera1.GetVoltage(20, 2) : 0.0;
-		QD3HeaterCautFF.Set(voltage < min || voltage > max);
+		QD3HeaterCautFF.Set(RCSVoltage3 < min || RCSVoltage3 > max);
 		QD3HeaterCautFF.Reset(lem->TempMonitorRotary.GetState() == 4);
 
 		//Quad 4
-		voltage = lem->pMission->GetLMNumber() <= 4 ? lem->scera1.GetVoltage(20, 1) : 0.0;
-		QD4HeaterCautFF.Set(voltage < min || voltage > max);
+		QD4HeaterCautFF.Set(RCSVoltage4 < min || RCSVoltage4 > max);
 		QD4HeaterCautFF.Reset(lem->TempMonitorRotary.GetState() == 5);
 
 		// S-Band Antenna Electronic Drive Assembly < -64.08F or > 152.63F
 		SBDHeaterCautFF.Set(lem->scera2.GetVoltage(21, 2) < 1.743 || lem->scera2.GetVoltage(21, 2) > 4.421);
 		SBDHeaterCautFF.Reset(lem->TempMonitorRotary.GetState() == 6);
 
-		//Set CW Light
-		if (LRHeaterCautFF.IsSet() || RRHeaterCautFF.IsSet() || SBDHeaterCautFF.IsSet() || QD1HeaterCautFF.IsSet() || QD2HeaterCautFF.IsSet() || QD3HeaterCautFF.IsSet() || QD4HeaterCautFF.IsSet())
+		//Set CW Light (LR Heater FF can still be set on all missions, but is ignored on LM-5 and subsequent)
+		if ((lem->pMission->GetLMNumber() <= 4 && LRHeaterCautFF.IsSet()) || RRHeaterCautFF.IsSet() || SBDHeaterCautFF.IsSet() || QD1HeaterCautFF.IsSet() || QD2HeaterCautFF.IsSet() || QD3HeaterCautFF.IsSet() || QD4HeaterCautFF.IsSet())
 			SetLight(2, 6, 1);
 		else
 			SetLight(2, 6, 0);


### PR DESCRIPTION
After some discussion on discord and some look at the EFDs the heater logic should be updated from it's current state. Specifically on LM 8+ the quad connections now connect to a constant voltage source from the MA reset circuit, which remains between the maximum and minimum value of the comparators, hence keeping the warning light off. This voltage is unknown to me currently, so I have selected a value somewhere between the maximum and minimum limits of the warning.
<img width="2176" height="1161" alt="image" src="https://github.com/user-attachments/assets/379d2a60-204d-4951-8008-063f0279ce59" />
<img width="1463" height="577" alt="image" src="https://github.com/user-attachments/assets/e4b918b4-119a-4bb8-b11b-83a525ba7008" />

---

As well as this, the LR logic was incorrect. From LM-5, instead of being cut and capped, the connection was remade, but connected through an always low AND gate (from a removed stage enable circuit), hence the FF can still be set, but will never get through to the alarm logic.
<img width="2101" height="304" alt="image" src="https://github.com/user-attachments/assets/fcdd2265-8b1b-4410-a84d-cbe53c4fe028" />

---

Finally, the water quantity light was removed (taped over) on LM-9+, due to the quantity system being replaced by a pressure system, and has been removed for those missions:

<img width="734" height="357" alt="image" src="https://github.com/user-attachments/assets/ee7e78d2-b3f6-438b-afaa-ebbcdeaed6d9" />

(Note: The quantity light change will cause a spurious master alarm on old scenario load, as the light state changes, which triggers an alarm, this will not happen after the first time, or on new scenarios)

This did come with a change to the quantity gauge as well, which is not simulated currently:

<img width="346" height="568" alt="image" src="https://github.com/user-attachments/assets/25599427-286c-4004-a2bc-7e139b2feabf" />

