### PR TITLE
Remove kill rotation from PAMFD GNC, reorder buttons in checklist MFD

### DIFF
--- a/Orbitersdk/samples/ProjectApollo/src_mfd/ProjectApolloChecklistMFD.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_mfd/ProjectApolloChecklistMFD.cpp
@@ -172,10 +172,10 @@ ProjectApolloChecklistMFD::~ProjectApolloChecklistMFD ()
 char *ProjectApolloChecklistMFD::ButtonLabel (int bt)
 {
 	// 2nd was "MET", disabled for now, MET is shown by default
-	static char *labelCHKLST[12] = {"NAV","","INFO","EXEC","FLSH","AUTO","PgUP","UP","BCK","GOTO","DN","PgDN"};
-	static char *labelCHKLSTActiveItem[12] = {"NAV","UNDO","INFO","EXEC","FLSH","AUTO","PgUP","UP","PRO","FAIL","DN","PgDN"};
-	static char *labelCHKLSTNAV[12] = {"BCK","","INFO","EXEC","FLSH","AUTO","PgUP","UP","SEL","REV","DN","PgDN"};
-	static char *labelCHKLSTREV[12] = {"NAV","","INFO","","","AUTO","PgUP","UP","","","DN","PgDN"};
+	static char *labelCHKLST[12] = {"NAV","","INFO","AUTO","EXEC","FLSH","PgUP","UP","BCK","GOTO","DN","PgDN"};
+	static char *labelCHKLSTActiveItem[12] = {"NAV","UNDO","INFO","AUTO","EXEC","FLSH","PgUP","UP","PRO","FAIL","DN","PgDN"};
+	static char *labelCHKLSTNAV[12] = {"BCK","","INFO","AUTO","EXEC","FLSH","PgUP","UP","SEL","REV","DN","PgDN"};
+	static char *labelCHKLSTREV[12] = {"NAV","","INFO","","","","PgUP","UP","","","DN","PgDN"};
 	static char *labelCHKLSTINFO[12] = {"BCK","","","","","","","","","","",""};
 
 	if (screen == PROG_CHKLST) {
@@ -204,9 +204,9 @@ int ProjectApolloChecklistMFD::ButtonMenu (const MFDBUTTONMENU **menu) const
 		// {"Toggle Display","Mission Elapsed Time",'M'},
 		{0,0,0},
 		{"More Information","About This Step",'N'},
+		{"Toggle AutoComplete",0,';'},
 		{"Toggle Automatic", "Checklist execution", 'E'},
 		{"Toggle Flashing",0,'L'},
-		{"Toggle AutoComplete",0,';'},
 		{"Scroll Up","One Page",'['},
 		{"Scroll Up","One Line",'U'},
 		{"Back To", "Active Item", 'B'},
@@ -219,9 +219,9 @@ int ProjectApolloChecklistMFD::ButtonMenu (const MFDBUTTONMENU **menu) const
 		// {"Toggle Display","Mission Elapsed Time",'M'},
 		{"Undo","Last Step",'B'},
 		{"More Information","About This Step",'N'},
+		{"Toggle AutoComplete",0,';'},
 		{"Toggle Automatic", "Checklist execution", 'E'},
 		{"Toggle Flashing",0,'L'},
-		{"Toggle AutoComplete",0,';'},
 		{"Scroll Up","One Page",'['},
 		{"Scroll Up","One Line",'U'},
 		{"Step Succeeds",0,'P'},
@@ -234,9 +234,9 @@ int ProjectApolloChecklistMFD::ButtonMenu (const MFDBUTTONMENU **menu) const
 		// {"Toggle Display","Mission Elapsed Time",'M'},
 		{0,0,0},
 		{"More Information","About This Checklist",'N'},
+		{"Toggle AutoComplete",0,';'},
 		{"Toggle Automatic", "Checklist execution", 'E'},
 		{"Toggle Flashing",0,'L'},
-		{"Toggle AutoComplete",0,';'},
 		{"Scroll Up","One Page",'['},
 		{"Scroll Up","One Line",'U'},
 		{"Select Checklist",0,'P'},
@@ -304,10 +304,10 @@ bool ProjectApolloChecklistMFD::ConsumeButton (int bt, int event)
 {
 	if (!(event & PANEL_MOUSE_LBDOWN)) return false;
 
-	static const DWORD btkeyCHKLST[12] = { OAPI_KEY_C,0,OAPI_KEY_N,OAPI_KEY_E,OAPI_KEY_L,OAPI_KEY_SEMICOLON,OAPI_KEY_LBRACKET,OAPI_KEY_U,OAPI_KEY_B,OAPI_KEY_R,OAPI_KEY_J,OAPI_KEY_RBRACKET };
-	static const DWORD btkeyCHKLSTActiveItem[12] = { OAPI_KEY_C,OAPI_KEY_B,OAPI_KEY_N,OAPI_KEY_E,OAPI_KEY_L,OAPI_KEY_SEMICOLON,OAPI_KEY_LBRACKET,OAPI_KEY_U,OAPI_KEY_P,OAPI_KEY_F,OAPI_KEY_J,OAPI_KEY_RBRACKET};
-	static const DWORD btkeyCHKLSTNAV[12] = { OAPI_KEY_C,OAPI_KEY_M,OAPI_KEY_N,OAPI_KEY_E,OAPI_KEY_L,OAPI_KEY_SEMICOLON,OAPI_KEY_LBRACKET,OAPI_KEY_U,OAPI_KEY_P,OAPI_KEY_R,OAPI_KEY_J,OAPI_KEY_RBRACKET};
-	static const DWORD btkeyCHKLSTREV[12] = { OAPI_KEY_C,OAPI_KEY_M,OAPI_KEY_N,0,0,OAPI_KEY_SEMICOLON,OAPI_KEY_LBRACKET,OAPI_KEY_U,0,0,OAPI_KEY_J,OAPI_KEY_RBRACKET};
+	static const DWORD btkeyCHKLST[12] = { OAPI_KEY_C,0,OAPI_KEY_N,OAPI_KEY_SEMICOLON,OAPI_KEY_E,OAPI_KEY_L,OAPI_KEY_LBRACKET,OAPI_KEY_U,OAPI_KEY_B,OAPI_KEY_R,OAPI_KEY_J,OAPI_KEY_RBRACKET };
+	static const DWORD btkeyCHKLSTActiveItem[12] = { OAPI_KEY_C,OAPI_KEY_B,OAPI_KEY_N,OAPI_KEY_SEMICOLON,OAPI_KEY_E,OAPI_KEY_L,OAPI_KEY_LBRACKET,OAPI_KEY_U,OAPI_KEY_P,OAPI_KEY_F,OAPI_KEY_J,OAPI_KEY_RBRACKET};
+	static const DWORD btkeyCHKLSTNAV[12] = { OAPI_KEY_C,OAPI_KEY_M,OAPI_KEY_N,OAPI_KEY_SEMICOLON,OAPI_KEY_E,OAPI_KEY_L,OAPI_KEY_LBRACKET,OAPI_KEY_U,OAPI_KEY_P,OAPI_KEY_R,OAPI_KEY_J,OAPI_KEY_RBRACKET};
+	static const DWORD btkeyCHKLSTREV[12] = { OAPI_KEY_C,OAPI_KEY_M,OAPI_KEY_N,0,0,0,OAPI_KEY_LBRACKET,OAPI_KEY_U,0,0,OAPI_KEY_J,OAPI_KEY_RBRACKET};
 	static const DWORD btkeyCHKLSTINFO[12] = { OAPI_KEY_B,OAPI_KEY_M,0,0,0,0,0,0,0,0,0,0};
 
 	if (screen == PROG_CHKLST)

--- a/Orbitersdk/samples/ProjectApollo/src_mfd/ProjectApolloMFD.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_mfd/ProjectApolloMFD.cpp
@@ -2205,12 +2205,13 @@ void ProjectApolloMFD::menuSetSLPage()
 	screen = m_buttonPages.page.SL;
 	m_buttonPages.SelectPage(this, screen);
 }
-
+//Kill rotation function; retained commented out in the event the function is needed later for debugging
+/*
 void ProjectApolloMFD::menuKillRot()
 {
 	g_Data.killrot ? g_Data.killrot = 0 : g_Data.killrot = 1;
 }
-
+*/
 void ProjectApolloMFD::menuSaveEMSScroll()
 {
 	if (saturn)

--- a/Orbitersdk/samples/ProjectApollo/src_mfd/ProjectApolloMFD.h
+++ b/Orbitersdk/samples/ProjectApollo/src_mfd/ProjectApolloMFD.h
@@ -82,7 +82,8 @@ public:
 	void menuSetFailuresPage();
 	void menuSetSLPage();
 
-	void menuKillRot();
+	//Kill rotation function; retained commented out in the event the function is needed later for debugging
+	//void menuKillRot();
 	void menuSaveEMSScroll();
 	void menuVAGCCoreDump();
 	void menuChangeLaunchTime();

--- a/Orbitersdk/samples/ProjectApollo/src_mfd/ProjectApolloMFDButtons.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_mfd/ProjectApolloMFDButtons.cpp
@@ -35,9 +35,8 @@ ProjectApolloMFDButtons::ProjectApolloMFDButtons()
 	RegisterFunction("DBG", OAPI_KEY_D, &ProjectApolloMFD::menuSetDebugPage);
 
 
-	static const MFDBUTTONMENU mnuGNC[5] = {
+	static const MFDBUTTONMENU mnuGNC[4] = {
 		{ "Back", 0, 'B' },
-		{ "Kill rotation", 0, 'K' },
 		{ "Save EMS scroll", 0, 'E' },
 		{ "Virtual AGC core dump", 0, 'D' },
 		{ "Change Saturn launch time", 0, 'T' }
@@ -46,7 +45,6 @@ ProjectApolloMFDButtons::ProjectApolloMFDButtons()
 	page.GNC = RegisterPage(mnuGNC, sizeof(mnuGNC) / sizeof(MFDBUTTONMENU));
 
 	RegisterFunction("BCK", OAPI_KEY_B, &ProjectApolloMFD::menuSetMainPage);
-	RegisterFunction("KILR", OAPI_KEY_K, &ProjectApolloMFD::menuKillRot);
 	RegisterFunction("EMS", OAPI_KEY_E, &ProjectApolloMFD::menuSaveEMSScroll);
 	RegisterFunction("DMP", OAPI_KEY_D, &ProjectApolloMFD::menuVAGCCoreDump);
 	RegisterFunction("TLO", OAPI_KEY_T, &ProjectApolloMFD::menuChangeLaunchTime);


### PR DESCRIPTION
- Remove kill rotation from PAMFD GNC
- Reorder AUTO EXEC FLASH to better align with use and display in checklist MFD